### PR TITLE
feat(core): S55 — Contract type, defineContract helper, isContract type guard

### DIFF
--- a/packages/core/src/contract.test.ts
+++ b/packages/core/src/contract.test.ts
@@ -46,6 +46,10 @@ describe('isContract', () => {
   it('returns false when output is null', () => {
     expect(isContract({ value: 'x', output: null })).toBe(false);
   });
+
+  it('returns false when output is an array', () => {
+    expect(isContract({ value: 'x', output: [] })).toBe(false);
+  });
 });
 
 describe('defineContract', () => {
@@ -56,6 +60,10 @@ describe('defineContract', () => {
 
   it('does not throw when id is omitted', () => {
     expect(() => defineContract({ value: 'x', output: {} })).not.toThrow();
+  });
+
+  it('does not throw when id is explicitly undefined', () => {
+    expect(() => defineContract({ id: undefined, value: 'x', output: {} })).not.toThrow();
   });
 
   it('does not throw when id is a valid non-empty string', () => {

--- a/packages/core/src/contract.test.ts
+++ b/packages/core/src/contract.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'bun:test';
+import { z } from 'zod';
+import { defineContract, isContract } from './contract.js';
+
+describe('isContract', () => {
+  it('returns true for a minimal valid object', () => {
+    expect(isContract({ value: 'x', output: {} })).toBe(true);
+  });
+
+  it('returns true for object with id set', () => {
+    expect(isContract({ id: 'auth.jwt', value: 'x', output: {} })).toBe(true);
+  });
+
+  it('returns true for object without id — id is optional and not checked', () => {
+    expect(isContract({ value: 'x', output: { name: z.string() } })).toBe(true);
+  });
+
+  it('returns false for null', () => {
+    expect(isContract(null)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isContract(undefined)).toBe(false);
+  });
+
+  it('returns false for a number', () => {
+    expect(isContract(42)).toBe(false);
+  });
+
+  it('returns false for a string', () => {
+    expect(isContract('string')).toBe(false);
+  });
+
+  it('returns false for object missing value', () => {
+    expect(isContract({ output: {} })).toBe(false);
+  });
+
+  it('returns false for object missing output', () => {
+    expect(isContract({ value: 'x' })).toBe(false);
+  });
+
+  it('returns false when value is not a string', () => {
+    expect(isContract({ value: 42, output: {} })).toBe(false);
+  });
+
+  it('returns false when output is null', () => {
+    expect(isContract({ value: 'x', output: null })).toBe(false);
+  });
+});
+
+describe('defineContract', () => {
+  it('returns the exact object passed to it when valid', () => {
+    const contract = { value: 'x', output: {} };
+    expect(defineContract(contract)).toBe(contract);
+  });
+
+  it('does not throw when id is omitted', () => {
+    expect(() => defineContract({ value: 'x', output: {} })).not.toThrow();
+  });
+
+  it('does not throw when id is a valid non-empty string', () => {
+    expect(() => defineContract({ id: 'auth.jwt', value: 'x', output: {} })).not.toThrow();
+  });
+
+  it('throws when id is an empty string', () => {
+    expect(() => defineContract({ id: '', value: 'x', output: {} })).toThrow(
+      'id must be a non-empty string',
+    );
+  });
+
+  it('throws when id is whitespace only', () => {
+    expect(() => defineContract({ id: '   ', value: 'x', output: {} })).toThrow(
+      'id must be a non-empty string',
+    );
+  });
+
+  it('enforces typed invariant argument — compile-time check via typed fixture', () => {
+    // If r is not typed as { name: string }, the _: string assignment below is a compile error.
+    const contract = defineContract({
+      value: 'typed invariant test',
+      output: { name: z.string() },
+      invariants: [
+        (r) => {
+          const _: string = r.name;
+          return _.length > 0;
+        },
+      ],
+    });
+    expect(isContract(contract)).toBe(true);
+  });
+});

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+
+export interface Contract<
+  T extends Record<string, z.ZodTypeAny> = Record<string, z.ZodTypeAny>,
+> {
+  id?: string;
+  value: string;
+  output: T;
+  invariants?: Array<(r: z.infer<z.ZodObject<T>>) => boolean>;
+  consumes?: Contract[];
+  forbids?: string[];
+  status?: 'complete' | 'active' | 'pending';
+  closedBy?: string;
+  closedWhen?: string;
+  dependsOn?: Contract[];
+}
+
+export function defineContract<T extends Record<string, z.ZodTypeAny>>(
+  contract: Contract<T>,
+): Contract<T> {
+  if ('id' in contract && contract.id !== undefined && contract.id.trim() === '') {
+    throw new Error('defineContract: id must be a non-empty string if provided');
+  }
+  return contract;
+}
+
+export function isContract(value: unknown): value is Contract {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'value' in value &&
+    typeof (value as Record<string, unknown>).value === 'string' &&
+    'output' in value &&
+    typeof (value as Record<string, unknown>).output === 'object' &&
+    (value as Record<string, unknown>).output !== null
+  );
+}

--- a/packages/core/src/contract.ts
+++ b/packages/core/src/contract.ts
@@ -32,6 +32,7 @@ export function isContract(value: unknown): value is Contract {
     typeof (value as Record<string, unknown>).value === 'string' &&
     'output' in value &&
     typeof (value as Record<string, unknown>).output === 'object' &&
-    (value as Record<string, unknown>).output !== null
+    (value as Record<string, unknown>).output !== null &&
+    !Array.isArray((value as Record<string, unknown>).output)
   );
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,3 +15,4 @@ export * from './reconciler/index.js';
 export * from './reconciler/import-suggestions.js';
 export * from './config.js';
 export * from './utils/paths.js';
+export * from './contract.js';


### PR DESCRIPTION
## Sprint 8 — S55

Closes #66

### What

Introduces the `Contract<T>` type system that `.contract.ts` files are built on.

- `Contract<T>` interface — generic over Zod output schema, with `id`, `value`, `output`, `invariants`, `consumes`, and lifecycle fields
- `defineContract<T>()` — validates `id` is non-empty if provided, returns the contract unchanged
- `isContract()` — type guard checking `value: string` and `output: object`; `id` intentionally not checked (optional)
- All three re-exported from `packages/core/src/index.ts`

### Why

S56 (extractor), S57 (scan wiring), S58 (pipeline), and S59 (status) all depend on these types being stable and tested first.

### Tests

17 tests in `packages/core/src/contract.test.ts`. Full suite: 196/196 passing.