### PR TITLE
feat(core): S56 — TypeScript contract extractor (extractFromContractFile)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "packages/cli": {
       "name": "@specferret/cli",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "bin": {
         "ferret": "./dist/bin/ferret.js",
       },
@@ -31,7 +31,7 @@
     },
     "packages/core": {
       "name": "@specferret/core",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "dependencies": {
         "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
@@ -40,6 +40,7 @@
         "tree-sitter": "^0.22.4",
         "tree-sitter-typescript": "^0.23.2",
         "zod": "^3.22.4",
+        "zod-to-json-schema": "^3.25.2",
       },
       "devDependencies": {
         "@types/bun": "^1.3.11",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,7 +29,8 @@
     "gray-matter": "^4.0.3",
     "tree-sitter": "^0.22.4",
     "tree-sitter-typescript": "^0.23.2",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "zod-to-json-schema": "^3.25.2"
   },
   "devDependencies": {
     "@types/bun": "^1.3.11",

--- a/packages/core/src/extractor/__fixtures__/cross-file-id.fixture.ts
+++ b/packages/core/src/extractor/__fixtures__/cross-file-id.fixture.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+import { externalWithId } from './external-with-id.fixture.js';
+
+// Consumes an external contract that has an explicit id — resolves via c.id
+export const myContract = {
+  value: 'Contract consuming known external',
+  output: { result: z.string() },
+  consumes: [externalWithId],
+};

--- a/packages/core/src/extractor/__fixtures__/cross-file-unresolved.fixture.ts
+++ b/packages/core/src/extractor/__fixtures__/cross-file-unresolved.fixture.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+import { externalNoId } from './external-no-id.fixture.js';
+
+// Consumes an external contract with no id — triggers exactly one warning
+export const myContract = {
+  value: 'Contract consuming unresolvable external',
+  output: { result: z.string() },
+  consumes: [externalNoId],
+};

--- a/packages/core/src/extractor/__fixtures__/empty.fixture.ts
+++ b/packages/core/src/extractor/__fixtures__/empty.fixture.ts
@@ -1,0 +1,4 @@
+// No ferret contracts here — only primitives and non-contract objects
+export const version = '1.0.0';
+export const count = 42;
+export const config = { debug: true };

--- a/packages/core/src/extractor/__fixtures__/external-no-id.fixture.ts
+++ b/packages/core/src/extractor/__fixtures__/external-no-id.fixture.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+// External contract with no id — cross-file refs to this will be unresolvable
+export const externalNoId = {
+  value: 'External contract without id',
+  output: { data: z.string() },
+};

--- a/packages/core/src/extractor/__fixtures__/external-with-id.fixture.ts
+++ b/packages/core/src/extractor/__fixtures__/external-with-id.fixture.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+// External contract with an explicit id — cross-file refs resolve via c.id
+export const externalWithId = {
+  value: 'External contract with explicit id',
+  output: { data: z.string() },
+  id: 'external.known.id',
+};

--- a/packages/core/src/extractor/__fixtures__/mixed.fixture.ts
+++ b/packages/core/src/extractor/__fixtures__/mixed.fixture.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+export const validContract = {
+  value: 'valid',
+  output: { name: z.string() },
+};
+
+export const anotherValid = {
+  value: 'another valid',
+  output: { count: z.number() },
+};
+
+// These should be skipped by isContract
+export const notAContract = 42;
+export const alsoNotAContract = 'just a string';
+export const missingOutput = { value: 'oops' };
+export const missingValue = { output: { x: z.string() } };

--- a/packages/core/src/extractor/__fixtures__/one-contract.fixture.ts
+++ b/packages/core/src/extractor/__fixtures__/one-contract.fixture.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const userContract = {
+  value: 'User shape contract',
+  output: {
+    id: z.string().uuid(),
+    name: z.string(),
+    email: z.string().email(),
+  },
+};

--- a/packages/core/src/extractor/__fixtures__/optional-fields.fixture.ts
+++ b/packages/core/src/extractor/__fixtures__/optional-fields.fixture.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const optionalFieldsContract = {
+  value: 'Contract with optional fields',
+  output: {
+    required_field: z.string(),
+    optional_field: z.string().optional(),
+    optional_number: z.number().optional(),
+  },
+};

--- a/packages/core/src/extractor/__fixtures__/same-file-consumes.fixture.ts
+++ b/packages/core/src/extractor/__fixtures__/same-file-consumes.fixture.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const baseContract = {
+  value: 'Base contract',
+  output: { token: z.string() },
+};
+
+export const dependentContract = {
+  value: 'Dependent contract that consumes baseContract',
+  output: { result: z.string() },
+  consumes: [baseContract],
+};

--- a/packages/core/src/extractor/__fixtures__/three-unresolved.fixture.ts
+++ b/packages/core/src/extractor/__fixtures__/three-unresolved.fixture.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+// Three separate unresolvable external references (not exported, no id)
+const ext1 = { value: 'ext1', output: { a: z.string() } };
+const ext2 = { value: 'ext2', output: { b: z.string() } };
+const ext3 = { value: 'ext3', output: { c: z.string() } };
+
+export const contractA = {
+  value: 'Contract A',
+  output: { x: z.string() },
+  consumes: [ext1],
+};
+
+export const contractB = {
+  value: 'Contract B',
+  output: { y: z.string() },
+  consumes: [ext2],
+};
+
+export const contractC = {
+  value: 'Contract C',
+  output: { zField: z.string() },
+  consumes: [ext3],
+};

--- a/packages/core/src/extractor/__fixtures__/throws-on-import.fixture.ts
+++ b/packages/core/src/extractor/__fixtures__/throws-on-import.fixture.ts
@@ -1,0 +1,3 @@
+// Fixture: throws synchronously at module top-level.
+// Used to verify that extractFromContractFile() does not swallow import errors.
+throw new Error('intentional module-level throw');

--- a/packages/core/src/extractor/frontmatter.ts
+++ b/packages/core/src/extractor/frontmatter.ts
@@ -20,7 +20,7 @@ export interface ExtractionResult {
     /** TypeScript symbol name (code-first contracts only). */
     sourceSymbol?: string;
   }>;
-  extractedBy: 'gray-matter' | 'tree-sitter';
+  extractedBy: 'gray-matter' | 'tree-sitter' | 'typescript';
   extractedAt: number; // unix ms
   warning?: 'no-frontmatter';
 }

--- a/packages/core/src/extractor/typescript-contract.test.ts
+++ b/packages/core/src/extractor/typescript-contract.test.ts
@@ -112,11 +112,32 @@ describe('extractFromContractFile', () => {
     }
   });
 
-  it('filePath is set correctly in the result', async () => {
-    const path = fixtures('one-contract.fixture.ts');
-    const result = await extractFromContractFile(path);
+  it('filePath and fileType are set correctly in the result', async () => {
+    const filePath = fixtures('one-contract.fixture.ts');
+    const result = await extractFromContractFile(filePath);
 
-    assert.equal(result.filePath, path);
-    assert.equal(result.fileType, 'spec');
+    assert.equal(result.filePath, filePath);
+    assert.equal(result.fileType, 'code');
+  });
+
+  it('fileType is "code" even when no contracts found', async () => {
+    const result = await extractFromContractFile(fixtures('empty.fixture.ts'));
+
+    assert.equal(result.fileType, 'code');
+  });
+
+  it('each contract has sourceFile and sourceSymbol populated', async () => {
+    const filePath = fixtures('one-contract.fixture.ts');
+    const result = await extractFromContractFile(filePath);
+
+    assert.equal(result.contracts[0].sourceFile, filePath);
+    assert.equal(result.contracts[0].sourceSymbol, 'userContract');
+  });
+
+  it('module that throws at top-level causes extractFromContractFile to reject', async () => {
+    await assert.rejects(
+      () => extractFromContractFile(fixtures('throws-on-import.fixture.ts')),
+      /intentional module-level throw/,
+    );
   });
 });

--- a/packages/core/src/extractor/typescript-contract.test.ts
+++ b/packages/core/src/extractor/typescript-contract.test.ts
@@ -1,0 +1,122 @@
+import assert from 'node:assert/strict';
+import { describe, expect, it, spyOn } from 'bun:test';
+import { join } from 'node:path';
+import { extractFromContractFile } from './typescript-contract.js';
+
+const fixtures = (name: string) => join(import.meta.dir, '__fixtures__', name);
+
+describe('extractFromContractFile', () => {
+  it('single valid export → one contract with correct id, shape, shape_hash, imports', async () => {
+    const result = await extractFromContractFile(fixtures('one-contract.fixture.ts'));
+
+    assert.equal(result.contracts.length, 1);
+    assert.equal(result.contracts[0].id, 'userContract');
+    assert.equal(typeof result.contracts[0].shape, 'object');
+    assert.equal(typeof result.contracts[0].shape_hash, 'string');
+    assert.equal(result.contracts[0].shape_hash.length, 64);
+    assert.deepEqual(result.contracts[0].imports, []);
+    assert.equal(result.warning, undefined);
+  });
+
+  it('multiple exports — only valid contracts extracted, non-contracts skipped', async () => {
+    const result = await extractFromContractFile(fixtures('mixed.fixture.ts'));
+
+    const ids = result.contracts.map((c) => c.id);
+    assert.equal(result.contracts.length, 2);
+    assert.ok(ids.includes('validContract'));
+    assert.ok(ids.includes('anotherValid'));
+  });
+
+  it('no ferret contracts → empty contracts array + warning: no-frontmatter', async () => {
+    const result = await extractFromContractFile(fixtures('empty.fixture.ts'));
+
+    assert.equal(result.contracts.length, 0);
+    assert.equal(result.warning, 'no-frontmatter');
+  });
+
+  it('extractedBy is always "typescript"', async () => {
+    const a = await extractFromContractFile(fixtures('one-contract.fixture.ts'));
+    const b = await extractFromContractFile(fixtures('empty.fixture.ts'));
+
+    assert.equal(a.extractedBy, 'typescript');
+    assert.equal(b.extractedBy, 'typescript');
+  });
+
+  it('extractedAt is a unix ms timestamp within 1s of Date.now()', async () => {
+    const before = Date.now();
+    const result = await extractFromContractFile(fixtures('one-contract.fixture.ts'));
+    const after = Date.now();
+
+    assert.ok(result.extractedAt >= before - 1000);
+    assert.ok(result.extractedAt <= after + 1000);
+  });
+
+  it('shape hash is deterministic — two runs on same file produce identical hash', async () => {
+    // Clear module cache by using a unique query approach isn't possible cleanly in Bun,
+    // but the hash must be stable across calls even with the cached module.
+    const r1 = await extractFromContractFile(fixtures('one-contract.fixture.ts'));
+    const r2 = await extractFromContractFile(fixtures('one-contract.fixture.ts'));
+
+    assert.equal(r1.contracts[0].shape_hash, r2.contracts[0].shape_hash);
+  });
+
+  it('zod schema with optional fields extracts without throwing', async () => {
+    await assert.doesNotReject(() =>
+      extractFromContractFile(fixtures('optional-fields.fixture.ts')),
+    );
+
+    const result = await extractFromContractFile(fixtures('optional-fields.fixture.ts'));
+    assert.equal(result.contracts.length, 1);
+    assert.equal(result.contracts[0].id, 'optionalFieldsContract');
+  });
+
+  it('same-file consumes reference resolves to the correct export name', async () => {
+    const result = await extractFromContractFile(fixtures('same-file-consumes.fixture.ts'));
+
+    const dependent = result.contracts.find((c) => c.id === 'dependentContract');
+    assert.ok(dependent, 'dependentContract not found in result');
+    assert.deepEqual(dependent.imports, ['baseContract']);
+  });
+
+  it('cross-file reference with explicit id resolves to c.id', async () => {
+    const result = await extractFromContractFile(fixtures('cross-file-id.fixture.ts'));
+
+    assert.equal(result.contracts.length, 1);
+    assert.deepEqual(result.contracts[0].imports, ['external.known.id']);
+  });
+
+  it('cross-file reference without id emits exactly one warning and returns [unresolved]', async () => {
+    const spy = spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const result = await extractFromContractFile(fixtures('cross-file-unresolved.fixture.ts'));
+
+      expect(spy.mock.calls.length).toBe(1);
+      assert.deepEqual(result.contracts[0].imports, ['[unresolved]']);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('three contracts each with unresolvable cross-file ref → three warnings emitted', async () => {
+    const spy = spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const result = await extractFromContractFile(fixtures('three-unresolved.fixture.ts'));
+
+      expect(spy.mock.calls.length).toBe(3);
+      assert.equal(result.contracts.length, 3);
+      result.contracts.forEach((c) => {
+        assert.deepEqual(c.imports, ['[unresolved]']);
+      });
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('filePath is set correctly in the result', async () => {
+    const path = fixtures('one-contract.fixture.ts');
+    const result = await extractFromContractFile(path);
+
+    assert.equal(result.filePath, path);
+    assert.equal(result.fileType, 'spec');
+  });
+});

--- a/packages/core/src/extractor/typescript-contract.ts
+++ b/packages/core/src/extractor/typescript-contract.ts
@@ -21,7 +21,7 @@ export async function extractFromContractFile(filePath: string): Promise<Extract
   if (exportNameMap.size === 0) {
     return {
       filePath,
-      fileType: 'spec',
+      fileType: 'code',
       contracts: [],
       extractedBy: 'typescript',
       extractedAt: Date.now(),
@@ -61,12 +61,14 @@ export async function extractFromContractFile(filePath: string): Promise<Extract
       shape,
       shape_hash,
       imports,
+      sourceFile: filePath,
+      sourceSymbol: exportName,
     });
   }
 
   return {
     filePath,
-    fileType: 'spec',
+    fileType: 'code',
     contracts,
     extractedBy: 'typescript',
     extractedAt: Date.now(),

--- a/packages/core/src/extractor/typescript-contract.ts
+++ b/packages/core/src/extractor/typescript-contract.ts
@@ -1,0 +1,74 @@
+// Extractor layer — turns a .contract.ts file into an ExtractionResult.
+// Uses Bun's native import() — no ts-morph, no AST, no compile step.
+
+import { z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+import { isContract } from '../contract.js';
+import { hashSchema } from './hash.js';
+import type { ExtractionResult } from './frontmatter.js';
+
+export async function extractFromContractFile(filePath: string): Promise<ExtractionResult> {
+  const mod = (await import(filePath)) as Record<string, unknown>;
+
+  // Pass 1: build Map<contract object reference → export name> for same-file resolution
+  const exportNameMap = new Map<object, string>();
+  for (const [exportName, exportValue] of Object.entries(mod)) {
+    if (isContract(exportValue)) {
+      exportNameMap.set(exportValue, exportName);
+    }
+  }
+
+  if (exportNameMap.size === 0) {
+    return {
+      filePath,
+      fileType: 'spec',
+      contracts: [],
+      extractedBy: 'typescript',
+      extractedAt: Date.now(),
+      warning: 'no-frontmatter',
+    };
+  }
+
+  const contracts: ExtractionResult['contracts'] = [];
+
+  for (const [exportName, exportValue] of Object.entries(mod)) {
+    if (!isContract(exportValue)) continue;
+
+    const shape = zodToJsonSchema(z.object(exportValue.output), { $refStrategy: 'none' });
+    const shape_hash = hashSchema(shape);
+
+    // Pass 2: resolve consumes → import IDs
+    const imports: string[] = [];
+    if (exportValue.consumes) {
+      for (const consumed of exportValue.consumes) {
+        const samefile = exportNameMap.get(consumed);
+        if (samefile !== undefined) {
+          imports.push(samefile);
+        } else if (consumed.id !== undefined) {
+          imports.push(consumed.id);
+        } else {
+          process.stderr.write(
+            `[specferret] warning: unresolvable consumes reference in '${filePath}' — export '${exportName}' references a contract with no id and no matching same-file export\n`,
+          );
+          imports.push('[unresolved]');
+        }
+      }
+    }
+
+    contracts.push({
+      id: exportName,
+      type: 'type',
+      shape,
+      shape_hash,
+      imports,
+    });
+  }
+
+  return {
+    filePath,
+    fileType: 'spec',
+    contracts,
+    extractedBy: 'typescript',
+    extractedAt: Date.now(),
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@
 // Do not export llm-fallback — dynamic import only, never a default export.
 
 export * from './extractor/frontmatter.js';
+export * from './extractor/typescript-contract.js';
 export * from './extractor/typescript.js';
 export * from './extractor/validator.js';
 export * from './extractor/contract-types.js';


### PR DESCRIPTION
## Summary

- Implements `extractFromContractFile(filePath): Promise<ExtractionResult>` in `packages/core/src/extractor/typescript-contract.ts`
- Uses Bun-native `await import(filePath)` — no ts-morph, no AST, no compile step
- Two-pass resolver for `consumes`: reference equality lookup → `c.id` fallback → `[unresolved]` + stderr warning
- One `process.stderr.write()` warning per unresolvable reference (testable count)
- Converts Zod `output` to JSON Schema via `zod-to-json-schema` (`$refStrategy: 'none'`) + `hashSchema()`
- Adds `'typescript'` to `extractedBy` union in `frontmatter.ts`
- Adds `zod-to-json-schema` dependency
- Re-exports `extractFromContractFile` from `packages/core/src/index.ts`

## Test plan

- [x] 12 tests in `typescript-contract.test.ts` covering all S56 acceptance criteria
- [x] Single valid export → correct id, shape, shape_hash, imports
- [x] Mixed exports (valid + invalid) → only valid ones extracted
- [x] Empty file → `warning: 'no-frontmatter'`
- [x] `extractedBy` always `'typescript'`
- [x] `extractedAt` within 1s of `Date.now()`
- [x] Shape hash deterministic across two calls
- [x] Optional Zod fields (`z.string().optional()`) extract without throwing
- [x] Same-file `consumes` resolves to export name (not `[object Object]`)
- [x] Cross-file ref with explicit `id` resolves to `c.id`
- [x] Cross-file ref without `id` → exactly one warning + `[unresolved]`
- [x] Three contracts × one unresolvable ref each → three warnings
- [x] All existing 120 tests still pass (132 total, 0 fail)

Closes #67