### PR TITLE
feat(core,cli): S57 — wire .contract.ts into file discovery and scan

### DIFF
--- a/packages/cli/bin/commands/scan.test.ts
+++ b/packages/cli/bin/commands/scan.test.ts
@@ -32,6 +32,92 @@ async function cleanupTmpDir(tmpDir: string): Promise<void> {
   }
 }
 
+describe("ferret scan — S57 .contract.ts discovery", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ferret-scan-ts-"));
+    runFerret(tmpDir, ["init", "--no-hook"]);
+  });
+
+  afterEach(async () => {
+    await cleanupTmpDir(tmpDir);
+  });
+
+  it("discovers and processes both .contract.md and .contract.ts in the same scan", () => {
+    // .contract.md — standard gray-matter contract
+    fs.writeFileSync(
+      path.join(tmpDir, "contracts", "search.contract.md"),
+      `---\nferret:\n  id: api.search\n  type: api\n  shape:\n    type: object\n---\n`,
+      "utf-8",
+    );
+
+    // .contract.ts — no zod import needed; output: {} is a valid empty ZodObject for extraction
+    fs.writeFileSync(
+      path.join(tmpDir, "contracts", "auth.contract.ts"),
+      `export const authContract = {\n  value: 'JWT authentication contract',\n  output: {},\n};\n`,
+      "utf-8",
+    );
+
+    const result = runFerret(tmpDir, ["scan"]);
+
+    assert.equal(result.status, 0, `scan failed:\nstdout: ${result.stdout}\nstderr: ${result.stderr}`);
+    assert.match(result.stdout, /3 files scanned/);
+    assert.match(result.stdout, /3 contracts updated/);
+
+    // Verify context.json contains both contracts
+    const contextPath = path.join(tmpDir, ".ferret", "context.json");
+    assert.ok(fs.existsSync(contextPath), "context.json was not written");
+    const context = JSON.parse(fs.readFileSync(contextPath, "utf-8"));
+    const ids = context.contracts.map((c: { id: string }) => c.id);
+    assert.ok(ids.includes("api.search"), `api.search not in context: ${JSON.stringify(ids)}`);
+    assert.ok(ids.includes("authContract"), `authContract not in context: ${JSON.stringify(ids)}`);
+  });
+
+  it(".contract.ts with no valid exports emits a warning and is skipped without crashing", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "contracts", "empty.contract.ts"),
+      `export const version = '1.0.0';\n`,
+      "utf-8",
+    );
+
+    const result = runFerret(tmpDir, ["scan"]);
+
+    assert.equal(result.status, 0, `scan crashed:\nstdout: ${result.stdout}\nstderr: ${result.stderr}`);
+    assert.match(result.stderr, /no ferret frontmatter — skipped/);
+  });
+
+  it("opt-out via contractParsers.typescript=false skips .contract.ts discovery", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "contracts", "search.contract.md"),
+      `---\nferret:\n  id: api.search\n  type: api\n  shape:\n    type: object\n---\n`,
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "contracts", "auth.contract.ts"),
+      `export const authContract = { value: 'auth', output: {} };\n`,
+      "utf-8",
+    );
+
+    // Write config with typescript discovery disabled
+    const configPath = path.join(tmpDir, "ferret.config.json");
+    const existing = JSON.parse(fs.readFileSync(configPath, "utf-8")) as Record<string, unknown>;
+    existing.contractParsers = { typescript: false };
+    fs.writeFileSync(configPath, JSON.stringify(existing, null, 2), "utf-8");
+
+    const result = runFerret(tmpDir, ["scan"]);
+
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /2 files scanned/);
+
+    const contextPath = path.join(tmpDir, ".ferret", "context.json");
+    const context = JSON.parse(fs.readFileSync(contextPath, "utf-8"));
+    const ids = context.contracts.map((c: { id: string }) => c.id);
+    assert.ok(ids.includes("api.search"));
+    assert.ok(!ids.includes("authContract"), "authContract should not be present when typescript=false");
+  });
+});
+
 describe("ferret scan — #31 error handling", () => {
   let tmpDir: string;
 

--- a/packages/cli/bin/commands/scan.test.ts
+++ b/packages/cli/bin/commands/scan.test.ts
@@ -52,7 +52,8 @@ describe("ferret scan — S57 .contract.ts discovery", () => {
       "utf-8",
     );
 
-    // .contract.ts — no zod import needed; output: {} is a valid empty ZodObject for extraction
+    // .contract.ts — output: {} is a plain empty schema-definition map; z.object({}) accepts it
+    // as a valid empty Zod object schema, so extraction succeeds with no fields.
     fs.writeFileSync(
       path.join(tmpDir, "contracts", "auth.contract.ts"),
       `export const authContract = {\n  value: 'JWT authentication contract',\n  output: {},\n};\n`,

--- a/packages/cli/bin/commands/scan.ts
+++ b/packages/cli/bin/commands/scan.ts
@@ -3,7 +3,8 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { execSync } from 'node:child_process';
 import { glob } from 'glob';
-import { extractFromSpecFile, compareSchemas, writeContext, getStore, loadConfig, findProjectRoot, hashSchema } from '@specferret/core';
+import { extractFromSpecFile, extractFromContractFile, compareSchemas, writeContext, getStore, loadConfig, findProjectRoot, hashSchema } from '@specferret/core';
+import type { ExtractionResult } from '@specferret/core';
 import { randomUUID } from 'node:crypto';
 import pc from 'picocolors';
 
@@ -30,6 +31,12 @@ export const scanCommand = new Command('scan')
         const pattern = config.filePattern ?? '**/*.contract.md';
         filesToScan = await glob(pattern, { cwd: specDir, absolute: false });
         filesToScan = filesToScan.map((f) => path.join(config.specDir, f));
+
+        // Also discover .contract.ts files (opt-out model: enabled unless contractParsers.typescript === false)
+        if (config.contractParsers?.typescript !== false) {
+          const tsFiles = await glob('**/*.contract.ts', { cwd: specDir, absolute: false });
+          filesToScan = [...filesToScan, ...tsFiles.map((f) => path.join(config.specDir, f))];
+        }
       }
 
       // --changed flag: filter to staged files only
@@ -57,9 +64,13 @@ export const scanCommand = new Command('scan')
 
         const content = fs.readFileSync(absFile, 'utf-8');
 
-        let result: ReturnType<typeof extractFromSpecFile>;
+        let result: ExtractionResult;
         try {
-          result = extractFromSpecFile(relFile, content);
+          if (absFile.endsWith('.contract.ts')) {
+            result = await extractFromContractFile(absFile);
+          } else {
+            result = extractFromSpecFile(relFile, content);
+          }
         } catch (error: unknown) {
           failed++;
           const reason = error instanceof Error ? error.message : String(error);

--- a/packages/cli/bin/commands/scan.ts
+++ b/packages/cli/bin/commands/scan.ts
@@ -35,7 +35,11 @@ export const scanCommand = new Command('scan')
         // Also discover .contract.ts files (opt-out model: enabled unless contractParsers.typescript === false)
         if (config.contractParsers?.typescript !== false) {
           const tsFiles = await glob('**/*.contract.ts', { cwd: specDir, absolute: false });
-          filesToScan = [...filesToScan, ...tsFiles.map((f) => path.join(config.specDir, f))];
+          const mapped = tsFiles.map((f) => path.join(config.specDir, f));
+          // Deduplicate: a custom filePattern could already match .contract.ts files,
+          // which would cause them to be processed twice (once via extractFromSpecFile,
+          // once via extractFromContractFile). Use a Set to prevent duplicate entries.
+          filesToScan = [...new Set([...filesToScan, ...mapped])];
         }
       }
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -14,6 +14,9 @@ export interface FerretConfig {
     include: string[];
     watchNodes?: string[];
   };
+  contractParsers?: {
+    typescript?: boolean;
+  };
 }
 
 export const DEFAULT_CONFIG: FerretConfig = {


### PR DESCRIPTION
## Summary

- `FerretConfig` gains `contractParsers?: { typescript?: boolean }` — opt-out model (enabled by default)
- `ferret scan` globs `**/*.contract.ts` under `specDir` unless `contractParsers.typescript === false`
- Branches on file extension in scan loop: `.contract.ts` → `extractFromContractFile(absFile)`, otherwise `extractFromSpecFile(relFile, content)`
- `.contract.ts` with no valid exports → `warning: 'no-frontmatter'` → warning to stderr + skip, no crash
- `ferret lint` picks up `.contract.ts` automatically via its `runScan → scanCommand` delegation path — zero changes to `lint.ts`

## Test plan

- [x] Integration: mixed `.contract.md` + `.contract.ts` scan → both contracts in `context.json` (3 files scanned, 3 contracts updated)
- [x] Integration: `.contract.ts` with no valid exports → `no ferret frontmatter — skipped` on stderr, exit 0
- [x] Integration: `contractParsers.typescript=false` in config → `.contract.ts` skipped, only `.contract.md` scanned
- [x] All existing scan error handling tests pass (3 tests, unchanged)
- [x] Full CLI suite 81/81 green
- [x] Full core suite 135/135 green

Closes #68