### PR TITLE
feat(cli): S58 — thread .contract.ts through upward-classifier and ID collision detection

### DIFF
--- a/packages/cli/bin/commands/lint.test.ts
+++ b/packages/cli/bin/commands/lint.test.ts
@@ -481,6 +481,89 @@ describe("ferret lint — #31 fail-fast scan errors", () => {
   });
 });
 
+describe("ferret lint — S58 .contract.ts upward-classifier and ID collision", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ferret-lint-s58-"));
+    runFerret(tmpDir, ["init", "--no-hook"]);
+    runFerret(tmpDir, ["scan"]);
+  });
+
+  afterEach(async () => {
+    await cleanupTmpDir(tmpDir);
+  });
+
+  stableIt(
+    "lint exits 0 and does not crash when .contract.ts contracts are present",
+    () => {
+      fs.writeFileSync(
+        path.join(tmpDir, "contracts", "auth.contract.ts"),
+        `export const authContract = { value: 'JWT auth contract', output: {} };\n`,
+        "utf-8",
+      );
+
+      // Scan to establish baseline in the store
+      runFerret(tmpDir, ["scan"]);
+
+      const result = runFerret(tmpDir, ["lint"]);
+      assert.equal(
+        result.status,
+        0,
+        `lint crashed:\nstdout: ${result.stdout}\nstderr: ${result.stderr}`,
+      );
+      assert.match(result.stdout, /0 drift/);
+    },
+  );
+
+  stableIt(
+    "--ci JSON output includes upwardDrift field when .contract.ts contracts are present",
+    () => {
+      fs.writeFileSync(
+        path.join(tmpDir, "contracts", "auth.contract.ts"),
+        `export const authContract = { value: 'JWT auth contract', output: {} };\n`,
+        "utf-8",
+      );
+
+      runFerret(tmpDir, ["scan"]);
+
+      const result = runFerret(tmpDir, ["lint", "--ci", "--ci-baseline", "rebuild"]);
+      assert.equal(result.status, 0);
+      const json = JSON.parse(result.stdout) as Record<string, unknown>;
+      assert.ok("upwardDrift" in json, "upwardDrift field missing from CI output");
+      assert.ok(Array.isArray(json.upwardDrift));
+      assert.equal(json.consistent, true);
+    },
+  );
+
+  stableIt(
+    "ID collision between .contract.md and .contract.ts is reported on stderr",
+    () => {
+      // .contract.md declares id: sharedContract
+      fs.writeFileSync(
+        path.join(tmpDir, "contracts", "shared.contract.md"),
+        `---\nferret:\n  id: sharedContract\n  type: api\n  shape:\n    type: object\n---\n`,
+        "utf-8",
+      );
+      // .contract.ts also exports sharedContract — same ID
+      fs.writeFileSync(
+        path.join(tmpDir, "contracts", "shared.contract.ts"),
+        `export const sharedContract = { value: 'shared', output: {} };\n`,
+        "utf-8",
+      );
+
+      const result = runFerret(tmpDir, ["scan"]);
+
+      assert.equal(result.status, 0, `scan failed:\nstderr: ${result.stderr}`);
+      assert.match(
+        result.stderr,
+        /CONFLICT sharedContract/,
+        `expected CONFLICT on stderr, got: ${result.stderr}`,
+      );
+    },
+  );
+});
+
 describe("ferret lint — #30 severity classification", () => {
   let tmpDir: string;
 

--- a/packages/cli/bin/commands/lint.test.ts
+++ b/packages/cli/bin/commands/lint.test.ts
@@ -1,18 +1,18 @@
-import assert from "node:assert/strict";
-import * as fs from "node:fs";
-import * as os from "node:os";
-import * as path from "node:path";
-import { spawnSync } from "node:child_process";
-import { fileURLToPath } from "node:url";
-import { describe, it, beforeEach, afterEach } from "bun:test";
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { describe, it, beforeEach, afterEach } from 'bun:test';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const ferretBin = path.resolve(__dirname, "../ferret.ts");
+const ferretBin = path.resolve(__dirname, '../ferret.ts');
 
 function runFerret(cwd: string, args: string[]): ReturnType<typeof spawnSync> {
   return spawnSync(process.execPath, [ferretBin, ...args], {
     cwd,
-    encoding: "utf-8",
+    encoding: 'utf-8',
     timeout: 10_000,
   });
 }
@@ -27,7 +27,7 @@ async function cleanupTmpDir(tmpDir: string): Promise<void> {
       fs.rmSync(tmpDir, { recursive: true, force: true });
       return;
     } catch (error: any) {
-      if (error?.code !== "EBUSY" || attempt === 19) {
+      if (error?.code !== 'EBUSY' || attempt === 19) {
         throw error;
       }
       await new Promise((resolve) => setTimeout(resolve, 100));
@@ -35,209 +35,183 @@ async function cleanupTmpDir(tmpDir: string): Promise<void> {
   }
 }
 
-describe("ferret lint — S07 acceptance criteria", () => {
+describe('ferret lint — S07 acceptance criteria', () => {
   let tmpDir: string;
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ferret-lint-test-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ferret-lint-test-'));
     // Lint tests use committed baseline mode, so create context.json once.
-    runFerret(tmpDir, ["init", "--no-hook"]);
-    runFerret(tmpDir, ["scan"]);
+    runFerret(tmpDir, ['init', '--no-hook']);
+    runFerret(tmpDir, ['scan']);
   });
 
   afterEach(async () => {
     await cleanupTmpDir(tmpDir);
   });
 
-  stableIt("exits 0 on a clean project with no drift", () => {
-    const result = runFerret(tmpDir, ["lint"]);
+  stableIt('exits 0 on a clean project with no drift', () => {
+    const result = runFerret(tmpDir, ['lint']);
     assert.equal(result.status, 0);
   });
 
-  stableIt("prints the clean-state summary line to stdout", () => {
-    const result = runFerret(tmpDir, ["lint"]);
+  stableIt('prints the clean-state summary line to stdout', () => {
+    const result = runFerret(tmpDir, ['lint']);
     // Expected: ✓ ferret  N contracts  0 drift  Xms
     assert.match(result.stdout, /0 drift\s+\d+ms/);
   });
 
-  stableIt("produces no stderr on a clean run", () => {
-    const result = runFerret(tmpDir, ["lint"]);
-    assert.equal(result.stderr, "");
+  stableIt('produces no stderr on a clean run', () => {
+    const result = runFerret(tmpDir, ['lint']);
+    assert.equal(result.stderr, '');
   });
 
-  stableIt("--ci flag outputs valid JSON to stdout", () => {
-    const result = runFerret(tmpDir, [
-      "lint",
-      "--ci",
-      "--ci-baseline",
-      "rebuild",
-    ]);
+  stableIt('--ci flag outputs valid JSON to stdout', () => {
+    const result = runFerret(tmpDir, ['lint', '--ci', '--ci-baseline', 'rebuild']);
     assert.doesNotThrow(() => JSON.parse(result.stdout));
   });
 
-  stableIt(
-    "--ci JSON has all required fields: version, consistent, breaking, nonBreaking, flagged, timestamp",
-    () => {
-      const result = runFerret(tmpDir, [
-        "lint",
-        "--ci",
-        "--ci-baseline",
-        "rebuild",
-      ]);
-      const json = JSON.parse(result.stdout) as Record<string, unknown>;
-      assert.ok("version" in json, "missing version");
-      assert.ok("consistent" in json, "missing consistent");
-      assert.ok("breaking" in json, "missing breaking");
-      assert.ok("nonBreaking" in json, "missing nonBreaking");
-      assert.ok("flagged" in json, "missing flagged");
-      assert.ok("timestamp" in json, "missing timestamp");
-    },
-  );
-
-  stableIt("--ci JSON has correct types for each field", () => {
-    const result = runFerret(tmpDir, ["lint", "--ci"]);
+  stableIt('--ci JSON has all required fields: version, consistent, breaking, nonBreaking, flagged, timestamp', () => {
+    const result = runFerret(tmpDir, ['lint', '--ci', '--ci-baseline', 'rebuild']);
     const json = JSON.parse(result.stdout) as Record<string, unknown>;
-    assert.equal(typeof json.version, "string");
-    assert.equal(typeof json.consistent, "boolean");
-    assert.equal(typeof json.breaking, "number");
-    assert.equal(typeof json.nonBreaking, "number");
-    assert.ok(Array.isArray(json.flagged));
-    assert.equal(typeof json.timestamp, "string");
+    assert.ok('version' in json, 'missing version');
+    assert.ok('consistent' in json, 'missing consistent');
+    assert.ok('breaking' in json, 'missing breaking');
+    assert.ok('nonBreaking' in json, 'missing nonBreaking');
+    assert.ok('flagged' in json, 'missing flagged');
+    assert.ok('timestamp' in json, 'missing timestamp');
   });
 
-  stableIt("--ci exits 0 on a consistent (drift-free) project", () => {
-    const result = runFerret(tmpDir, ["lint", "--ci"]);
+  stableIt('--ci JSON has correct types for each field', () => {
+    const result = runFerret(tmpDir, ['lint', '--ci']);
+    const json = JSON.parse(result.stdout) as Record<string, unknown>;
+    assert.equal(typeof json.version, 'string');
+    assert.equal(typeof json.consistent, 'boolean');
+    assert.equal(typeof json.breaking, 'number');
+    assert.equal(typeof json.nonBreaking, 'number');
+    assert.ok(Array.isArray(json.flagged));
+    assert.equal(typeof json.timestamp, 'string');
+  });
+
+  stableIt('--ci exits 0 on a consistent (drift-free) project', () => {
+    const result = runFerret(tmpDir, ['lint', '--ci']);
     assert.equal(result.status, 0);
   });
 
-  stableIt("--ci consistent field is true on a clean project", () => {
-    const result = runFerret(tmpDir, ["lint", "--ci"]);
+  stableIt('--ci consistent field is true on a clean project', () => {
+    const result = runFerret(tmpDir, ['lint', '--ci']);
     const json = JSON.parse(result.stdout) as Record<string, unknown>;
     assert.equal(json.consistent, true);
   });
 
-  stableIt("--ci output contains zero ANSI escape codes", () => {
-    const result = runFerret(tmpDir, ["lint", "--ci"]);
+  stableIt('--ci output contains zero ANSI escape codes', () => {
+    const result = runFerret(tmpDir, ['lint', '--ci']);
     // ANSI sequences start with ESC (\x1b)
     assert.doesNotMatch(result.stdout, /\x1b\[/);
   });
 
-  stableIt("includes a timing value in the clean-state summary output", () => {
-    const result = runFerret(tmpDir, ["lint"]);
+  stableIt('includes a timing value in the clean-state summary output', () => {
+    const result = runFerret(tmpDir, ['lint']);
     assert.equal(result.status, 0);
     const match = result.stdout.match(/(\d+)ms/);
-    assert.ok(match, "output should contain a timing value in ms");
+    assert.ok(match, 'output should contain a timing value in ms');
   });
 });
 
-describe("ferret lint — S30 import integrity", () => {
+describe('ferret lint — S30 import integrity', () => {
   let tmpDir: string;
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ferret-lint-integrity-"));
-    runFerret(tmpDir, ["init", "--no-hook"]);
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ferret-lint-integrity-'));
+    runFerret(tmpDir, ['init', '--no-hook']);
   });
 
   afterEach(async () => {
     await cleanupTmpDir(tmpDir);
   });
 
-  stableIt(
-    "fails on unresolved imports with actionable local diagnostics",
-    () => {
-      const contractPath = path.join(
-        tmpDir,
-        "contracts",
-        "example.contract.md",
-      );
-      fs.writeFileSync(
-        contractPath,
-        `---\nferret:\n  id: api.GET/example\n  type: api\n  imports:\n    - api.GET/missing\n  shape:\n    type: object\n    properties:\n      ok:\n        type: boolean\n---\n`,
-        "utf-8",
-      );
-
-      const result = runFerret(tmpDir, ["lint"]);
-      assert.equal(result.status, 2);
-      assert.match(result.stdout, /import integrity violations/);
-      assert.match(result.stdout, /api.GET\/example/);
-      assert.match(result.stdout, /contracts[\\/]example\.contract\.md/);
-      assert.match(result.stdout, /expected target api.GET\/missing/);
-      assert.match(result.stdout, /orphaned contract/);
-      assert.match(result.stdout, /remediation:/);
-    },
-  );
-
-  stableIt("includes transitive chain context for unresolved imports", () => {
+  stableIt('fails on unresolved imports with actionable local diagnostics', () => {
+    const contractPath = path.join(tmpDir, 'contracts', 'example.contract.md');
     fs.writeFileSync(
-      path.join(tmpDir, "contracts", "root.contract.md"),
-      `---\nferret:\n  id: api.GET/root\n  type: api\n  imports:\n    - api.GET/mid\n  shape:\n    type: object\n---\n`,
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(tmpDir, "contracts", "mid.contract.md"),
-      `---\nferret:\n  id: api.GET/mid\n  type: api\n  imports:\n    - api.GET/leaf\n  shape:\n    type: object\n---\n`,
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(tmpDir, "contracts", "leaf.contract.md"),
-      `---\nferret:\n  id: api.GET/leaf\n  type: api\n  imports:\n    - api.GET/missing\n  shape:\n    type: object\n---\n`,
-      "utf-8",
+      contractPath,
+      `---\nferret:\n  id: api.GET/example\n  type: api\n  imports:\n    - api.GET/missing\n  shape:\n    type: object\n    properties:\n      ok:\n        type: boolean\n---\n`,
+      'utf-8',
     );
 
-    const result = runFerret(tmpDir, ["lint"]);
+    const result = runFerret(tmpDir, ['lint']);
     assert.equal(result.status, 2);
-    assert.match(
-      result.stdout,
-      /transitive chain: api.GET\/root -> api.GET\/mid -> api.GET\/leaf -> api.GET\/missing/,
-    );
+    assert.match(result.stdout, /import integrity violations/);
+    assert.match(result.stdout, /api.GET\/example/);
+    assert.match(result.stdout, /contracts[\\/]example\.contract\.md/);
+    assert.match(result.stdout, /expected target api.GET\/missing/);
+    assert.match(result.stdout, /orphaned contract/);
+    assert.match(result.stdout, /remediation:/);
   });
 
-  stableIt("fails on self-imports with actionable local diagnostics", () => {
-    const contractPath = path.join(tmpDir, "contracts", "example.contract.md");
+  stableIt('includes transitive chain context for unresolved imports', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'contracts', 'root.contract.md'),
+      `---\nferret:\n  id: api.GET/root\n  type: api\n  imports:\n    - api.GET/mid\n  shape:\n    type: object\n---\n`,
+      'utf-8',
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'contracts', 'mid.contract.md'),
+      `---\nferret:\n  id: api.GET/mid\n  type: api\n  imports:\n    - api.GET/leaf\n  shape:\n    type: object\n---\n`,
+      'utf-8',
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'contracts', 'leaf.contract.md'),
+      `---\nferret:\n  id: api.GET/leaf\n  type: api\n  imports:\n    - api.GET/missing\n  shape:\n    type: object\n---\n`,
+      'utf-8',
+    );
+
+    const result = runFerret(tmpDir, ['lint']);
+    assert.equal(result.status, 2);
+    assert.match(result.stdout, /transitive chain: api.GET\/root -> api.GET\/mid -> api.GET\/leaf -> api.GET\/missing/);
+  });
+
+  stableIt('fails on self-imports with actionable local diagnostics', () => {
+    const contractPath = path.join(tmpDir, 'contracts', 'example.contract.md');
     fs.writeFileSync(
       contractPath,
       `---\nferret:\n  id: api.GET/example\n  type: api\n  imports:\n    - api.GET/example\n  shape:\n    type: object\n    properties:\n      ok:\n        type: boolean\n---\n`,
-      "utf-8",
+      'utf-8',
     );
 
-    const result = runFerret(tmpDir, ["lint"]);
+    const result = runFerret(tmpDir, ['lint']);
     assert.equal(result.status, 2);
     assert.match(result.stdout, /self-import api.GET\/example/);
   });
 
-  stableIt("fails on circular imports with concise local diagnostics", () => {
+  stableIt('fails on circular imports with concise local diagnostics', () => {
     fs.writeFileSync(
-      path.join(tmpDir, "contracts", "a.contract.md"),
+      path.join(tmpDir, 'contracts', 'a.contract.md'),
       `---\nferret:\n  id: api.GET/a\n  type: api\n  imports:\n    - api.GET/b\n  shape:\n    type: object\n---\n`,
-      "utf-8",
+      'utf-8',
     );
     fs.writeFileSync(
-      path.join(tmpDir, "contracts", "b.contract.md"),
+      path.join(tmpDir, 'contracts', 'b.contract.md'),
       `---\nferret:\n  id: api.GET/b\n  type: api\n  imports:\n    - api.GET/a\n  shape:\n    type: object\n---\n`,
-      "utf-8",
+      'utf-8',
     );
 
-    const result = runFerret(tmpDir, ["lint"]);
+    const result = runFerret(tmpDir, ['lint']);
     assert.equal(result.status, 2);
-    assert.match(
-      result.stdout,
-      /circular import api.GET\/a -> api.GET\/b -> api.GET\/a/,
-    );
+    assert.match(result.stdout, /circular import api.GET\/a -> api.GET\/b -> api.GET\/a/);
   });
 
-  stableIt("reports integrity violations in machine-readable CI output", () => {
-    runFerret(tmpDir, ["scan"]);
+  stableIt('reports integrity violations in machine-readable CI output', () => {
+    runFerret(tmpDir, ['scan']);
 
-    const contractPath = path.join(tmpDir, "contracts", "example.contract.md");
+    const contractPath = path.join(tmpDir, 'contracts', 'example.contract.md');
     fs.writeFileSync(
       contractPath,
       `---\nferret:\n  id: api.GET/example\n  type: api\n  imports:\n    - api.GET/missing\n  shape:\n    type: object\n---\n`,
-      "utf-8",
+      'utf-8',
     );
 
-    const result = runFerret(tmpDir, ["lint", "--ci"]);
+    const result = runFerret(tmpDir, ['lint', '--ci']);
     assert.equal(result.status, 2);
-    assert.equal(result.stderr, "");
+    assert.equal(result.stderr, '');
     assert.doesNotMatch(result.stdout, /\x1b\[/);
 
     const json = JSON.parse(result.stdout) as {
@@ -265,401 +239,320 @@ describe("ferret lint — S30 import integrity", () => {
     assert.equal(json.nonBreaking, 0);
     assert.equal(json.flagged.length, 0);
     assert.equal(json.integrityViolations.unresolvedImports.length, 1);
-    assert.equal(
-      json.integrityViolations.unresolvedImports[0].contractId,
-      "api.GET/example",
-    );
-    assert.equal(
-      json.integrityViolations.unresolvedImports[0].importPath,
-      "api.GET/missing",
-    );
-    assert.equal(
-      json.integrityViolations.unresolvedImports[0].expectedTargetId,
-      "api.GET/missing",
-    );
+    assert.equal(json.integrityViolations.unresolvedImports[0].contractId, 'api.GET/example');
+    assert.equal(json.integrityViolations.unresolvedImports[0].importPath, 'api.GET/missing');
+    assert.equal(json.integrityViolations.unresolvedImports[0].expectedTargetId, 'api.GET/missing');
     assert.equal(json.integrityViolations.selfImports.length, 0);
     assert.equal(json.integrityViolations.circularImports.length, 0);
     assert.equal(json.integrityViolations.orphanedContracts.length, 1);
-    assert.equal(
-      json.integrityViolations.orphanedContracts[0].contractId,
-      "api.GET/example",
-    );
+    assert.equal(json.integrityViolations.orphanedContracts[0].contractId, 'api.GET/example');
   });
 });
 
-describe("ferret lint — S31 import suggestions", () => {
+describe('ferret lint — S31 import suggestions', () => {
   let tmpDir: string;
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ferret-lint-suggestions-"));
-    runFerret(tmpDir, ["init", "--no-hook"]);
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ferret-lint-suggestions-'));
+    runFerret(tmpDir, ['init', '--no-hook']);
   });
 
   afterEach(async () => {
     await cleanupTmpDir(tmpDir);
   });
 
-  stableIt("emits warning-level suggestions without failing lint", () => {
+  stableIt('emits warning-level suggestions without failing lint', () => {
     fs.writeFileSync(
-      path.join(tmpDir, "contracts", "a.contract.md"),
+      path.join(tmpDir, 'contracts', 'a.contract.md'),
       `---\nferret:\n  id: api.GET/a\n  type: api\n  shape:\n    type: object\n    properties:\n      token:\n        type: string\n      userId:\n        type: string\n---\n`,
-      "utf-8",
+      'utf-8',
     );
 
     fs.writeFileSync(
-      path.join(tmpDir, "contracts", "b.contract.md"),
+      path.join(tmpDir, 'contracts', 'b.contract.md'),
       `---\nferret:\n  id: auth.jwt\n  type: api\n  shape:\n    type: object\n    properties:\n      token:\n        type: string\n      userId:\n        type: string\n      expiresAt:\n        type: string\n---\n`,
-      "utf-8",
+      'utf-8',
     );
 
-    const result = runFerret(tmpDir, ["lint"]);
+    const result = runFerret(tmpDir, ['lint']);
     assert.equal(result.status, 0);
     assert.match(result.stdout, /import suggestions/);
     assert.match(result.stdout, /consider importing auth.jwt/);
     assert.match(result.stdout, /high confidence|medium confidence/);
   });
 
-  stableIt(
-    "suppresses suggestions in --ci mode unless explicitly requested",
-    () => {
-      fs.writeFileSync(
-        path.join(tmpDir, "contracts", "a.contract.md"),
-        `---\nferret:\n  id: api.GET/a\n  type: api\n  shape:\n    type: object\n    properties:\n      token:\n        type: string\n      userId:\n        type: string\n---\n`,
-        "utf-8",
-      );
+  stableIt('suppresses suggestions in --ci mode unless explicitly requested', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'contracts', 'a.contract.md'),
+      `---\nferret:\n  id: api.GET/a\n  type: api\n  shape:\n    type: object\n    properties:\n      token:\n        type: string\n      userId:\n        type: string\n---\n`,
+      'utf-8',
+    );
 
-      fs.writeFileSync(
-        path.join(tmpDir, "contracts", "b.contract.md"),
-        `---\nferret:\n  id: auth.jwt\n  type: api\n  shape:\n    type: object\n    properties:\n      token:\n        type: string\n      userId:\n        type: string\n      expiresAt:\n        type: string\n---\n`,
-        "utf-8",
-      );
+    fs.writeFileSync(
+      path.join(tmpDir, 'contracts', 'b.contract.md'),
+      `---\nferret:\n  id: auth.jwt\n  type: api\n  shape:\n    type: object\n    properties:\n      token:\n        type: string\n      userId:\n        type: string\n      expiresAt:\n        type: string\n---\n`,
+      'utf-8',
+    );
 
-      const result = runFerret(tmpDir, [
-        "lint",
-        "--ci",
-        "--ci-baseline",
-        "rebuild",
-      ]);
-      assert.equal(result.status, 0);
-      const json = JSON.parse(result.stdout) as Record<string, unknown>;
-      assert.equal("importSuggestions" in json, false);
-    },
-  );
+    const result = runFerret(tmpDir, ['lint', '--ci', '--ci-baseline', 'rebuild']);
+    assert.equal(result.status, 0);
+    const json = JSON.parse(result.stdout) as Record<string, unknown>;
+    assert.equal('importSuggestions' in json, false);
+  });
 
-  stableIt(
-    "includes suggestions in --ci mode when --ci-suggestions is set",
-    () => {
-      fs.writeFileSync(
-        path.join(tmpDir, "contracts", "a.contract.md"),
-        `---\nferret:\n  id: api.GET/a\n  type: api\n  shape:\n    type: object\n    properties:\n      token:\n        type: string\n      userId:\n        type: string\n---\n`,
-        "utf-8",
-      );
+  stableIt('includes suggestions in --ci mode when --ci-suggestions is set', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'contracts', 'a.contract.md'),
+      `---\nferret:\n  id: api.GET/a\n  type: api\n  shape:\n    type: object\n    properties:\n      token:\n        type: string\n      userId:\n        type: string\n---\n`,
+      'utf-8',
+    );
 
-      fs.writeFileSync(
-        path.join(tmpDir, "contracts", "b.contract.md"),
-        `---\nferret:\n  id: auth.jwt\n  type: api\n  shape:\n    type: object\n    properties:\n      token:\n        type: string\n      userId:\n        type: string\n      expiresAt:\n        type: string\n---\n`,
-        "utf-8",
-      );
+    fs.writeFileSync(
+      path.join(tmpDir, 'contracts', 'b.contract.md'),
+      `---\nferret:\n  id: auth.jwt\n  type: api\n  shape:\n    type: object\n    properties:\n      token:\n        type: string\n      userId:\n        type: string\n      expiresAt:\n        type: string\n---\n`,
+      'utf-8',
+    );
 
-      const result = runFerret(tmpDir, [
-        "lint",
-        "--ci",
-        "--ci-baseline",
-        "rebuild",
-        "--ci-suggestions",
-      ]);
-      assert.equal(result.status, 0);
-      const json = JSON.parse(result.stdout) as {
-        importSuggestions: Array<{
-          sourceContractId: string;
-          suggestedImportId: string;
-        }>;
-      };
-      assert.equal(Array.isArray(json.importSuggestions), true);
-      assert.equal(json.importSuggestions.length > 0, true);
-      assert.equal(json.importSuggestions[0].sourceContractId, "api.GET/a");
-      assert.equal(json.importSuggestions[0].suggestedImportId, "auth.jwt");
-    },
-  );
+    const result = runFerret(tmpDir, ['lint', '--ci', '--ci-baseline', 'rebuild', '--ci-suggestions']);
+    assert.equal(result.status, 0);
+    const json = JSON.parse(result.stdout) as {
+      importSuggestions: Array<{
+        sourceContractId: string;
+        suggestedImportId: string;
+      }>;
+    };
+    assert.equal(Array.isArray(json.importSuggestions), true);
+    assert.equal(json.importSuggestions.length > 0, true);
+    assert.equal(json.importSuggestions[0].sourceContractId, 'api.GET/a');
+    assert.equal(json.importSuggestions[0].suggestedImportId, 'auth.jwt');
+  });
 
-  stableIt("allows disabling suggestions via config", () => {
-    const configPath = path.join(tmpDir, "ferret.config.json");
-    const config = JSON.parse(fs.readFileSync(configPath, "utf-8")) as {
+  stableIt('allows disabling suggestions via config', () => {
+    const configPath = path.join(tmpDir, 'ferret.config.json');
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as {
       importSuggestions?: { enabled?: boolean };
     };
     config.importSuggestions = { enabled: false };
-    fs.writeFileSync(
-      configPath,
-      JSON.stringify(config, null, 2) + "\n",
-      "utf-8",
-    );
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
 
     fs.writeFileSync(
-      path.join(tmpDir, "contracts", "a.contract.md"),
+      path.join(tmpDir, 'contracts', 'a.contract.md'),
       `---\nferret:\n  id: api.GET/a\n  type: api\n  shape:\n    type: object\n    properties:\n      token:\n        type: string\n      userId:\n        type: string\n---\n`,
-      "utf-8",
+      'utf-8',
     );
 
     fs.writeFileSync(
-      path.join(tmpDir, "contracts", "b.contract.md"),
+      path.join(tmpDir, 'contracts', 'b.contract.md'),
       `---\nferret:\n  id: auth.jwt\n  type: api\n  shape:\n    type: object\n    properties:\n      token:\n        type: string\n      userId:\n        type: string\n      expiresAt:\n        type: string\n---\n`,
-      "utf-8",
+      'utf-8',
     );
 
-    const local = runFerret(tmpDir, ["lint"]);
+    const local = runFerret(tmpDir, ['lint']);
     assert.equal(local.status, 0);
     assert.doesNotMatch(local.stdout, /import suggestions/);
 
-    const ci = runFerret(tmpDir, [
-      "lint",
-      "--ci",
-      "--ci-baseline",
-      "rebuild",
-      "--ci-suggestions",
-    ]);
+    const ci = runFerret(tmpDir, ['lint', '--ci', '--ci-baseline', 'rebuild', '--ci-suggestions']);
     assert.equal(ci.status, 0);
     const json = JSON.parse(ci.stdout) as Record<string, unknown>;
-    assert.equal("importSuggestions" in json, false);
+    assert.equal('importSuggestions' in json, false);
   });
 });
 
-describe("ferret lint — #31 fail-fast scan errors", () => {
+describe('ferret lint — #31 fail-fast scan errors', () => {
   let tmpDir: string;
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ferret-lint-fail-fast-"));
-    runFerret(tmpDir, ["init", "--no-hook"]);
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ferret-lint-fail-fast-'));
+    runFerret(tmpDir, ['init', '--no-hook']);
   });
 
   afterEach(async () => {
     await cleanupTmpDir(tmpDir);
   });
 
-  stableIt("fails with actionable diagnostics on malformed frontmatter", () => {
-    fs.writeFileSync(
-      path.join(tmpDir, "contracts", "bad.contract.md"),
-      `---\nferret:\n  id: api.bad\n  type: api\n---\n`,
-      "utf-8",
-    );
+  stableIt('fails with actionable diagnostics on malformed frontmatter', () => {
+    fs.writeFileSync(path.join(tmpDir, 'contracts', 'bad.contract.md'), `---\nferret:\n  id: api.bad\n  type: api\n---\n`, 'utf-8');
 
-    const result = runFerret(tmpDir, ["lint"]);
+    const result = runFerret(tmpDir, ['lint']);
 
     assert.equal(result.status, 2);
-    assert.match(
-      result.stderr,
-      /scan failed for contracts[\\/]bad\.contract\.md/,
-    );
+    assert.match(result.stderr, /scan failed for contracts[\\/]bad\.contract\.md/);
     assert.match(result.stderr, /Missing required frontmatter fields/i);
     // Diagnostic must appear exactly once — no double-write from scan + lint
-    assert.equal(
-      (result.stderr.match(/scan failed for/g) ?? []).length,
-      1,
-      "diagnostic should appear exactly once on stderr",
-    );
+    assert.equal((result.stderr.match(/scan failed for/g) ?? []).length, 1, 'diagnostic should appear exactly once on stderr');
     assert.doesNotMatch(result.stderr, /ferret: ferret:/);
   });
 
-  stableIt("fails with actionable diagnostics on parser failures", () => {
+  stableIt('fails with actionable diagnostics on parser failures', () => {
     fs.writeFileSync(
-      path.join(tmpDir, "contracts", "broken-yaml.contract.md"),
+      path.join(tmpDir, 'contracts', 'broken-yaml.contract.md'),
       `---\nferret:\n  id: api.broken\n  type: api\n  shape:\n    type: object\n    properties:\n      bad: [unclosed\n---\n`,
-      "utf-8",
+      'utf-8',
     );
 
-    const result = runFerret(tmpDir, ["lint"]);
+    const result = runFerret(tmpDir, ['lint']);
 
     assert.equal(result.status, 2);
-    assert.match(
-      result.stderr,
-      /scan failed for contracts[\\/]broken-yaml\.contract\.md/,
-    );
-    assert.match(
-      result.stderr,
-      /YAML|end of the stream|missed comma|unexpected/i,
-    );
+    assert.match(result.stderr, /scan failed for contracts[\\/]broken-yaml\.contract\.md/);
+    assert.match(result.stderr, /YAML|end of the stream|missed comma|unexpected/i);
     assert.doesNotMatch(result.stderr, /ferret: ferret:/);
   });
 });
 
-describe("ferret lint — S58 .contract.ts upward-classifier and ID collision", () => {
+describe('ferret lint — S58 .contract.ts upward-classifier and ID collision', () => {
   let tmpDir: string;
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ferret-lint-s58-"));
-    runFerret(tmpDir, ["init", "--no-hook"]);
-    runFerret(tmpDir, ["scan"]);
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ferret-lint-s58-'));
+    runFerret(tmpDir, ['init', '--no-hook']);
+    runFerret(tmpDir, ['scan']);
   });
 
   afterEach(async () => {
     await cleanupTmpDir(tmpDir);
   });
 
-  stableIt(
-    "lint exits 0 and does not crash when .contract.ts contracts are present",
-    () => {
-      fs.writeFileSync(
-        path.join(tmpDir, "contracts", "auth.contract.ts"),
-        `export const authContract = { value: 'JWT auth contract', output: {} };\n`,
-        "utf-8",
-      );
+  stableIt('lint exits 0 and does not crash when .contract.ts contracts are present', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'contracts', 'auth.contract.ts'),
+      `export const authContract = { value: 'JWT auth contract', output: {} };\n`,
+      'utf-8',
+    );
 
-      // Scan to establish baseline in the store
-      runFerret(tmpDir, ["scan"]);
+    // Scan to establish baseline in the store
+    runFerret(tmpDir, ['scan']);
 
-      const result = runFerret(tmpDir, ["lint"]);
-      assert.equal(
-        result.status,
-        0,
-        `lint crashed:\nstdout: ${result.stdout}\nstderr: ${result.stderr}`,
-      );
-      assert.match(result.stdout, /0 drift/);
-    },
-  );
+    const result = runFerret(tmpDir, ['lint']);
+    assert.equal(result.status, 0, `lint crashed:\nstdout: ${result.stdout}\nstderr: ${result.stderr}`);
+    assert.match(result.stdout, /0 drift/);
+  });
 
-  stableIt(
-    "--ci JSON output includes upwardDrift field when .contract.ts contracts are present",
-    () => {
-      fs.writeFileSync(
-        path.join(tmpDir, "contracts", "auth.contract.ts"),
-        `export const authContract = { value: 'JWT auth contract', output: {} };\n`,
-        "utf-8",
-      );
+  stableIt('--ci JSON output includes upwardDrift field when .contract.ts contracts are present', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'contracts', 'auth.contract.ts'),
+      `export const authContract = { value: 'JWT auth contract', output: {} };\n`,
+      'utf-8',
+    );
 
-      runFerret(tmpDir, ["scan"]);
+    runFerret(tmpDir, ['scan']);
 
-      const result = runFerret(tmpDir, ["lint", "--ci", "--ci-baseline", "rebuild"]);
-      assert.equal(result.status, 0);
-      const json = JSON.parse(result.stdout) as Record<string, unknown>;
-      assert.ok("upwardDrift" in json, "upwardDrift field missing from CI output");
-      assert.ok(Array.isArray(json.upwardDrift));
-      assert.equal(json.consistent, true);
-    },
-  );
+    const result = runFerret(tmpDir, ['lint', '--ci', '--ci-baseline', 'rebuild']);
+    assert.equal(result.status, 0);
+    const json = JSON.parse(result.stdout) as Record<string, unknown>;
+    assert.ok('upwardDrift' in json, 'upwardDrift field missing from CI output');
+    assert.ok(Array.isArray(json.upwardDrift));
+    assert.equal(json.consistent, true);
+  });
 
-  stableIt(
-    "ID collision between .contract.md and .contract.ts is reported on stderr",
-    () => {
-      // .contract.md declares id: sharedContract
-      fs.writeFileSync(
-        path.join(tmpDir, "contracts", "shared.contract.md"),
-        `---\nferret:\n  id: sharedContract\n  type: api\n  shape:\n    type: object\n---\n`,
-        "utf-8",
-      );
-      // .contract.ts also exports sharedContract — same ID
-      fs.writeFileSync(
-        path.join(tmpDir, "contracts", "shared.contract.ts"),
-        `export const sharedContract = { value: 'shared', output: {} };\n`,
-        "utf-8",
-      );
+  stableIt('ID collision between .contract.md and .contract.ts is reported on stderr', () => {
+    // .contract.md declares id: sharedContract
+    fs.writeFileSync(
+      path.join(tmpDir, 'contracts', 'shared.contract.md'),
+      `---\nferret:\n  id: sharedContract\n  type: api\n  shape:\n    type: object\n---\n`,
+      'utf-8',
+    );
+    // .contract.ts also exports sharedContract — same ID
+    fs.writeFileSync(
+      path.join(tmpDir, 'contracts', 'shared.contract.ts'),
+      `export const sharedContract = { value: 'shared', output: {} };\n`,
+      'utf-8',
+    );
 
-      const result = runFerret(tmpDir, ["scan"]);
+    const result = runFerret(tmpDir, ['scan']);
 
-      assert.equal(result.status, 0, `scan failed:\nstderr: ${result.stderr}`);
-      assert.match(
-        result.stderr,
-        /CONFLICT sharedContract/,
-        `expected CONFLICT on stderr, got: ${result.stderr}`,
-      );
-    },
-  );
+    assert.equal(result.status, 0, `scan failed:\nstderr: ${result.stderr}`);
+    assert.match(result.stderr, /CONFLICT sharedContract/, `expected CONFLICT on stderr, got: ${result.stderr}`);
+  });
 });
 
-describe("ferret lint — #30 severity classification", () => {
+describe('ferret lint — #30 severity classification', () => {
   let tmpDir: string;
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ferret-lint-severity-"));
-    runFerret(tmpDir, ["init", "--no-hook"]);
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ferret-lint-severity-'));
+    runFerret(tmpDir, ['init', '--no-hook']);
   });
 
   afterEach(async () => {
     await cleanupTmpDir(tmpDir);
   });
 
-  stableIt(
-    "CI breaking/nonBreaking counts reflect trigger severity, not graph depth",
-    () => {
-      // Baseline: two contracts, downstream imports upstream
-      fs.writeFileSync(
-        path.join(tmpDir, "contracts", "upstream.contract.md"),
-        `---\nferret:\n  id: api.upstream\n  type: api\n  shape:\n    type: object\n    properties:\n      name:\n        type: string\n    required:\n      - name\n---\n`,
-        "utf-8",
-      );
-      fs.writeFileSync(
-        path.join(tmpDir, "contracts", "downstream.contract.md"),
-        `---\nferret:\n  id: api.downstream\n  type: api\n  imports:\n    - api.upstream\n  shape:\n    type: object\n    properties:\n      ok:\n        type: boolean\n---\n`,
-        "utf-8",
-      );
+  stableIt('CI breaking/nonBreaking counts reflect trigger severity, not graph depth', () => {
+    // Baseline: two contracts, downstream imports upstream
+    fs.writeFileSync(
+      path.join(tmpDir, 'contracts', 'upstream.contract.md'),
+      `---\nferret:\n  id: api.upstream\n  type: api\n  shape:\n    type: object\n    properties:\n      name:\n        type: string\n    required:\n      - name\n---\n`,
+      'utf-8',
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'contracts', 'downstream.contract.md'),
+      `---\nferret:\n  id: api.downstream\n  type: api\n  imports:\n    - api.upstream\n  shape:\n    type: object\n    properties:\n      ok:\n        type: boolean\n---\n`,
+      'utf-8',
+    );
 
-      // Scan baseline
-      runFerret(tmpDir, ["scan"]);
+    // Scan baseline
+    runFerret(tmpDir, ['scan']);
 
-      // Now introduce a breaking change to upstream (add a required field)
-      fs.writeFileSync(
-        path.join(tmpDir, "contracts", "upstream.contract.md"),
-        `---\nferret:\n  id: api.upstream\n  type: api\n  shape:\n    type: object\n    properties:\n      name:\n        type: string\n      email:\n        type: string\n    required:\n      - name\n      - email\n---\n`,
-        "utf-8",
-      );
+    // Now introduce a breaking change to upstream (add a required field)
+    fs.writeFileSync(
+      path.join(tmpDir, 'contracts', 'upstream.contract.md'),
+      `---\nferret:\n  id: api.upstream\n  type: api\n  shape:\n    type: object\n    properties:\n      name:\n        type: string\n      email:\n        type: string\n    required:\n      - name\n      - email\n---\n`,
+      'utf-8',
+    );
 
-      const result = runFerret(tmpDir, [
-        "lint",
-        "--ci",
-        "--ci-baseline",
-        "rebuild",
-      ]);
-      const json = JSON.parse(result.stdout) as {
-        breaking: number;
-        nonBreaking: number;
-        flagged: Array<{ triggeredByContractId: string; depth: number }>;
-      };
+    const result = runFerret(tmpDir, ['lint', '--ci', '--ci-baseline', 'rebuild']);
+    const json = JSON.parse(result.stdout) as {
+      breaking: number;
+      nonBreaking: number;
+      flagged: Array<{ triggeredByContractId: string; depth: number }>;
+    };
 
-      // The downstream node is flagged because upstream changed (breaking).
-      // Old bug: depth=1 counted as "breaking", depth>1 as "nonBreaking".
-      // Correct: the trigger contract (api.upstream) has status=needs-review,
-      // so ALL nodes it flagged are "breaking" regardless of depth.
-      assert.equal(json.breaking, json.flagged.length);
-      assert.equal(json.nonBreaking, 0);
-    },
-  );
+    // The downstream node is flagged because upstream changed (breaking).
+    // Old bug: depth=1 counted as "breaking", depth>1 as "nonBreaking".
+    // Correct: the trigger contract (api.upstream) has status=needs-review,
+    // so ALL nodes it flagged are "breaking" regardless of depth.
+    assert.equal(json.breaking, json.flagged.length);
+    assert.equal(json.nonBreaking, 0);
+  });
 
-  stableIt("human output counts match trigger severity for mixed drift", () => {
+  stableIt('human output counts match trigger severity for mixed drift', () => {
     // Baseline: two independent contracts
     fs.writeFileSync(
-      path.join(tmpDir, "contracts", "auth.contract.md"),
+      path.join(tmpDir, 'contracts', 'auth.contract.md'),
       `---\nferret:\n  id: api.auth\n  type: api\n  shape:\n    type: object\n    properties:\n      token:\n        type: string\n    required:\n      - token\n---\n`,
-      "utf-8",
+      'utf-8',
     );
     fs.writeFileSync(
-      path.join(tmpDir, "contracts", "profile.contract.md"),
+      path.join(tmpDir, 'contracts', 'profile.contract.md'),
       `---\nferret:\n  id: api.profile\n  type: api\n  imports:\n    - api.auth\n  shape:\n    type: object\n    properties:\n      name:\n        type: string\n---\n`,
-      "utf-8",
+      'utf-8',
     );
 
-    runFerret(tmpDir, ["scan"]);
+    runFerret(tmpDir, ['scan']);
 
     // Breaking change to auth (add required field)
     fs.writeFileSync(
-      path.join(tmpDir, "contracts", "auth.contract.md"),
+      path.join(tmpDir, 'contracts', 'auth.contract.md'),
       `---\nferret:\n  id: api.auth\n  type: api\n  shape:\n    type: object\n    properties:\n      token:\n        type: string\n      refreshToken:\n        type: string\n    required:\n      - token\n      - refreshToken\n---\n`,
-      "utf-8",
+      'utf-8',
     );
 
-    const result = runFerret(tmpDir, ["lint"]);
+    const result = runFerret(tmpDir, ['lint']);
     assert.equal(result.status, 1);
     // All flagged nodes are downstream of a breaking trigger
     assert.match(result.stdout, /1 breaking\s+0 non-breaking/);
   });
 
-  stableIt("no false non-zero exit on clean state after re-scan", () => {
+  stableIt('no false non-zero exit on clean state after re-scan', () => {
     fs.writeFileSync(
-      path.join(tmpDir, "contracts", "stable.contract.md"),
+      path.join(tmpDir, 'contracts', 'stable.contract.md'),
       `---\nferret:\n  id: api.stable\n  type: api\n  shape:\n    type: object\n    properties:\n      ok:\n        type: boolean\n---\n`,
-      "utf-8",
+      'utf-8',
     );
 
-    runFerret(tmpDir, ["scan"]);
+    runFerret(tmpDir, ['scan']);
     // Re-scan with identical content should remain clean
-    const result = runFerret(tmpDir, ["lint"]);
+    const result = runFerret(tmpDir, ['lint']);
     assert.equal(result.status, 0);
     assert.match(result.stdout, /0 drift/);
   });

--- a/packages/cli/bin/commands/lint.test.ts
+++ b/packages/cli/bin/commands/lint.test.ts
@@ -463,6 +463,36 @@ describe('ferret lint — S58 .contract.ts upward-classifier and ID collision', 
     assert.equal(result.status, 0, `scan failed:\nstderr: ${result.stderr}`);
     assert.match(result.stderr, /CONFLICT sharedContract/, `expected CONFLICT on stderr, got: ${result.stderr}`);
   });
+
+  stableIt(
+    'ID collision is detected when the first-defined file is unchanged on re-scan',
+    () => {
+      // Scan 1: shared.contract.md only — stored in the DB
+      fs.writeFileSync(
+        path.join(tmpDir, 'contracts', 'shared.contract.md'),
+        `---\nferret:\n  id: sharedContract\n  type: api\n  shape:\n    type: object\n---\n`,
+        'utf-8',
+      );
+      runFerret(tmpDir, ['scan']); // sharedContract now in store; file is "unchanged" on next scan
+
+      // Add .contract.ts with the same ID (new file — fileChanged = true)
+      fs.writeFileSync(
+        path.join(tmpDir, 'contracts', 'shared.contract.ts'),
+        `export const sharedContract = { value: 'shared', output: {} };\n`,
+        'utf-8',
+      );
+
+      // Scan 2: .md is unchanged (skipped by !fileChanged), .ts is new.
+      // Pre-seeding from the store must catch the collision.
+      const result = runFerret(tmpDir, ['scan']);
+      assert.equal(result.status, 0, `scan failed:\nstderr: ${result.stderr}`);
+      assert.match(
+        result.stderr,
+        /CONFLICT sharedContract/,
+        `expected CONFLICT on stderr, got: ${result.stderr}`,
+      );
+    },
+  );
 });
 
 describe('ferret lint — #30 severity classification', () => {

--- a/packages/cli/bin/commands/lint.ts
+++ b/packages/cli/bin/commands/lint.ts
@@ -12,6 +12,7 @@ import {
   readContextFile,
   classifyUpwardDrift,
   extractContractsFromTypeScript,
+  extractFromContractFile,
 } from '@specferret/core';
 import type { UpwardDriftResult } from '@specferret/core';
 import { parsePositiveMsBudget } from './parse-utils.js';
@@ -96,20 +97,31 @@ export const lintCommand = new Command('lint')
         if (!contract.code_source_file || !contract.code_source_symbol) continue;
         const sourceAbsPath = path.resolve(root, contract.code_source_file);
         if (!fs.existsSync(sourceAbsPath)) continue;
-        let fileContent: string;
+
+        let codeShape: unknown;
         try {
-          fileContent = fs.readFileSync(sourceAbsPath, 'utf-8');
+          if (sourceAbsPath.endsWith('.contract.ts')) {
+            // .contract.ts: use the TypeScript contract extractor (Zod-based, not tree-sitter)
+            const tsExtraction = await extractFromContractFile(sourceAbsPath);
+            const found = tsExtraction.contracts.find((c) => c.id === contract.code_source_symbol);
+            if (!found) continue;
+            codeShape = found.shape;
+          } else {
+            const fileContent = fs.readFileSync(sourceAbsPath, 'utf-8');
+            const extraction = extractContractsFromTypeScript(sourceAbsPath, fileContent);
+            const found = extraction.contracts.find((c) => c.sourceSymbol === contract.code_source_symbol);
+            if (!found) continue;
+            codeShape = found.shape;
+          }
         } catch {
           continue;
         }
-        const extraction = extractContractsFromTypeScript(sourceAbsPath, fileContent);
-        const codeContract = extraction.contracts.find((c) => c.sourceSymbol === contract.code_source_symbol);
-        if (!codeContract) continue;
+
         let declaredSchema: unknown = {};
         try {
           declaredSchema = JSON.parse(contract.shape_schema);
         } catch {}
-        const result = classifyUpwardDrift(contract.id, declaredSchema, codeContract.shape, contract.code_source_file, contract.code_source_symbol);
+        const result = classifyUpwardDrift(contract.id, declaredSchema, codeShape, contract.code_source_file, contract.code_source_symbol);
         if (result.driftClass !== 'NOOP') {
           upwardDrift.push(result);
         }

--- a/packages/cli/bin/commands/lint.ts
+++ b/packages/cli/bin/commands/lint.ts
@@ -14,7 +14,7 @@ import {
   extractContractsFromTypeScript,
   extractFromContractFile,
 } from '@specferret/core';
-import type { UpwardDriftResult } from '@specferret/core';
+import type { UpwardDriftResult, ExtractionResult } from '@specferret/core';
 import { parsePositiveMsBudget } from './parse-utils.js';
 import { buildLintDiagnostics, DIAGNOSTICS_SCHEMA_VERSION } from './diagnostics.js';
 
@@ -93,6 +93,9 @@ export const lintCommand = new Command('lint')
       // For each contract that has code source metadata, re-extract the live TypeScript
       // symbol and compare against the declared contract schema.
       const upwardDrift: UpwardDriftResult[] = [];
+      // Cache .contract.ts extractions — one file may export multiple contracts;
+      // without caching we'd re-import and evaluate it once per contract.
+      const tsExtractionCache = new Map<string, ExtractionResult>();
       for (const contract of contracts) {
         if (!contract.code_source_file || !contract.code_source_symbol) continue;
         const sourceAbsPath = path.resolve(root, contract.code_source_file);
@@ -102,7 +105,11 @@ export const lintCommand = new Command('lint')
         try {
           if (sourceAbsPath.endsWith('.contract.ts')) {
             // .contract.ts: use the TypeScript contract extractor (Zod-based, not tree-sitter)
-            const tsExtraction = await extractFromContractFile(sourceAbsPath);
+            let tsExtraction = tsExtractionCache.get(sourceAbsPath);
+            if (!tsExtraction) {
+              tsExtraction = await extractFromContractFile(sourceAbsPath);
+              tsExtractionCache.set(sourceAbsPath, tsExtraction);
+            }
             const found = tsExtraction.contracts.find((c) => c.id === contract.code_source_symbol);
             if (!found) continue;
             codeShape = found.shape;

--- a/packages/cli/bin/commands/scan.ts
+++ b/packages/cli/bin/commands/scan.ts
@@ -59,6 +59,20 @@ export const scanCommand = new Command('scan')
       let failed = 0;
       const seenContractIds = new Map<string, string>(); // contractId → first-seen relFile
 
+      // Pre-seed seenContractIds from the store so unchanged files (skipped by the
+      // !fileChanged continue) still participate in cross-file collision detection.
+      // Filter to files in filesToScan so stale / deleted entries don't cause false positives.
+      const filesToScanSet = new Set(filesToScan);
+      const storedContracts = await store.getContracts();
+      const storedNodes = await store.getNodes();
+      const nodeFilePaths = new Map(storedNodes.map((n) => [n.id, n.file_path]));
+      for (const c of storedContracts) {
+        const fp = nodeFilePaths.get(c.node_id);
+        if (fp && filesToScanSet.has(fp)) {
+          seenContractIds.set(c.id, fp);
+        }
+      }
+
       for (const relFile of filesToScan) {
         const absFile = path.resolve(root, relFile);
 
@@ -116,7 +130,9 @@ export const scanCommand = new Command('scan')
         const importIds = new Set<string>();
 
         for (const contract of result.contracts) {
-          // Detect ID collision across files in the same scan run
+          // Detect ID collision across files in the same scan run.
+          // Intentionally advisory-only (stderr, exit 0) so scan never blocks a partial result;
+          // CI pipelines that need to gate on this should parse stderr for CONFLICT.
           const existingFile = seenContractIds.get(contract.id);
           if (existingFile !== undefined && existingFile !== relFile) {
             process.stderr.write(`ferret: CONFLICT ${contract.id} — defined in both ${existingFile} and ${relFile}\n`);
@@ -160,7 +176,14 @@ export const scanCommand = new Command('scan')
             shape_schema: JSON.stringify(contract.shape),
             type: contract.type,
             status: nodeStatus,
-            ...(contract.sourceFile !== undefined && { code_source_file: contract.sourceFile }),
+            ...(contract.sourceFile !== undefined && {
+              // Normalize to project-relative path — extractFromContractFile supplies an
+              // absolute path; frontmatter extractors supply a relative one. Always store
+              // relative so DB and context.json are portable across machines.
+              code_source_file: path.isAbsolute(contract.sourceFile)
+                ? path.relative(root, contract.sourceFile).replace(/\\/g, '/')
+                : contract.sourceFile,
+            }),
             ...(contract.sourceSymbol !== undefined && { code_source_symbol: contract.sourceSymbol }),
           });
 

--- a/packages/cli/bin/commands/scan.ts
+++ b/packages/cli/bin/commands/scan.ts
@@ -57,6 +57,7 @@ export const scanCommand = new Command('scan')
       let changed = 0;
       let skipped = 0;
       let failed = 0;
+      const seenContractIds = new Map<string, string>(); // contractId → first-seen relFile
 
       for (const relFile of filesToScan) {
         const absFile = path.resolve(root, relFile);
@@ -115,6 +116,13 @@ export const scanCommand = new Command('scan')
         const importIds = new Set<string>();
 
         for (const contract of result.contracts) {
+          // Detect ID collision across files in the same scan run
+          const existingFile = seenContractIds.get(contract.id);
+          if (existingFile !== undefined && existingFile !== relFile) {
+            process.stderr.write(`ferret: CONFLICT ${contract.id} — defined in both ${existingFile} and ${relFile}\n`);
+          }
+          seenContractIds.set(contract.id, relFile);
+
           // Get previous contract for comparison
           const prevContract = await store.getContract(contract.id);
 


### PR DESCRIPTION
## Summary

- **`lint.ts`**: upward drift loop now branches on `.contract.ts` — uses `extractFromContractFile` (Zod-based) instead of tree-sitter, which previously silently skipped all `.contract.ts` contracts
- **`scan.ts`**: tracks `contractId → relFile` during each scan run; emits `CONFLICT <id> — defined in both <file1> and <file2>` to stderr when the same contract ID appears across multiple files
- **`lint.test.ts`**: 3 new S58 integration tests

## Test plan

- [ ] Lint exits 0 and prints `0 drift` when `.contract.ts` contracts are present
- [ ] `ferret lint --ci` JSON includes `upwardDrift` field with `.contract.ts` present
- [ ] ID collision between `.contract.md` and `.contract.ts` is reported on stderr
- [ ] All 219 existing tests still pass (`bun test` green)