### PR TITLE
feat(cli,core): S59 — ferret status command

### DIFF
--- a/packages/cli/bin/commands/status.test.ts
+++ b/packages/cli/bin/commands/status.test.ts
@@ -48,13 +48,7 @@ describe('ferret status — S59 acceptance criteria', () => {
     await cleanupTmpDir(tmpDir);
   });
 
-  stableIt('exits 0 on an empty store', () => {
-    const result = runFerret(tmpDir, ['status']);
-    assert.equal(result.status, 0);
-  });
-
-  stableIt('prints "0 contracts" on an empty store', () => {
-    // Status without scan: DB is empty (init does not scan)
+  stableIt('exits 0 and prints "0 contracts" on an empty store', () => {
     const result = runFerret(tmpDir, ['status']);
     assert.equal(result.status, 0);
     assert.match(result.stdout, /ferret status\s+0 contracts/);
@@ -82,6 +76,7 @@ describe('ferret status — S59 acceptance criteria', () => {
     assert.ok('timestamp' in json, 'missing timestamp');
     assert.ok('total' in json, 'missing total');
     assert.ok('stable' in json, 'missing stable');
+    assert.ok('roadmap' in json, 'missing roadmap');
     assert.ok('needsReview' in json, 'missing needsReview');
     assert.ok('contracts' in json, 'missing contracts');
   });

--- a/packages/cli/bin/commands/status.test.ts
+++ b/packages/cli/bin/commands/status.test.ts
@@ -1,0 +1,177 @@
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { describe, it, beforeEach, afterEach } from 'bun:test';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ferretBin = path.resolve(__dirname, '../ferret.ts');
+
+function runFerret(cwd: string, args: string[]): ReturnType<typeof spawnSync> {
+  return spawnSync(process.execPath, [ferretBin, ...args], {
+    cwd,
+    encoding: 'utf-8',
+    timeout: 10_000,
+  });
+}
+
+function stableIt(name: string, fn: () => void | Promise<void>): void {
+  it(name, fn, 15_000);
+}
+
+async function cleanupTmpDir(tmpDir: string): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      return;
+    } catch (error: any) {
+      if (error?.code !== 'EBUSY' || attempt === 19) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+  }
+}
+
+describe('ferret status — S59 acceptance criteria', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ferret-status-test-'));
+    runFerret(tmpDir, ['init', '--no-hook']);
+    // Do NOT run scan here — each test controls its own store state.
+  });
+
+  afterEach(async () => {
+    await cleanupTmpDir(tmpDir);
+  });
+
+  stableIt('exits 0 on an empty store', () => {
+    const result = runFerret(tmpDir, ['status']);
+    assert.equal(result.status, 0);
+  });
+
+  stableIt('prints "0 contracts" on an empty store', () => {
+    // Status without scan: DB is empty (init does not scan)
+    const result = runFerret(tmpDir, ['status']);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /ferret status\s+0 contracts/);
+  });
+
+  stableIt('exits 0 on a clean project with stable contracts', () => {
+    // Remove init sample so we control exactly what's in the store
+    fs.rmSync(path.join(tmpDir, 'contracts', 'example.contract.md'), { force: true });
+    fs.writeFileSync(
+      path.join(tmpDir, 'contracts', 'api.contract.md'),
+      '---\nferret:\n  id: api.endpoint\n  type: api\n  shape:\n    type: object\n---\n',
+      'utf-8',
+    );
+    runFerret(tmpDir, ['scan']);
+    const result = runFerret(tmpDir, ['status']);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /stable\s+1/);
+  });
+
+  stableIt('--json outputs valid JSON with required fields', () => {
+    const result = runFerret(tmpDir, ['status', '--json']);
+    assert.equal(result.status, 0);
+    const json = JSON.parse(result.stdout) as Record<string, unknown>;
+    assert.ok('version' in json, 'missing version');
+    assert.ok('timestamp' in json, 'missing timestamp');
+    assert.ok('total' in json, 'missing total');
+    assert.ok('stable' in json, 'missing stable');
+    assert.ok('needsReview' in json, 'missing needsReview');
+    assert.ok('contracts' in json, 'missing contracts');
+  });
+
+  stableIt('--json exits 0 even with no contracts', () => {
+    // No scan — DB is empty
+    const result = runFerret(tmpDir, ['status', '--json']);
+    assert.equal(result.status, 0);
+    const json = JSON.parse(result.stdout) as Record<string, unknown>;
+    assert.equal(json.total, 0);
+    assert.equal(json.needsReview, 0);
+    assert.deepEqual(json.contracts, []);
+  });
+
+  stableIt('shows NEEDS REVIEW section when breaking contract exists', () => {
+    const contractPath = path.join(tmpDir, 'contracts', 'api.contract.md');
+    fs.writeFileSync(
+      contractPath,
+      '---\nferret:\n  id: api.breaking\n  type: api\n  shape:\n    type: object\n    properties:\n      id:\n        type: string\n    required:\n      - id\n---\n',
+      'utf-8',
+    );
+    runFerret(tmpDir, ['scan']);
+    // Remove required field — breaking change
+    fs.writeFileSync(
+      contractPath,
+      '---\nferret:\n  id: api.breaking\n  type: api\n  shape:\n    type: object\n    properties:\n      id:\n        type: string\n---\n',
+      'utf-8',
+    );
+    runFerret(tmpDir, ['scan', '--force']);
+    const result = runFerret(tmpDir, ['status']);
+    assert.equal(result.status, 0);
+    assert.match(result.stdout, /NEEDS REVIEW/);
+    assert.match(result.stdout, /api\.breaking/);
+  });
+
+  stableIt('--json contracts array contains only needs-review entries', () => {
+    const contractPath = path.join(tmpDir, 'contracts', 'api.contract.md');
+    fs.writeFileSync(
+      contractPath,
+      '---\nferret:\n  id: api.breaking\n  type: api\n  shape:\n    type: object\n    properties:\n      id:\n        type: string\n    required:\n      - id\n---\n',
+      'utf-8',
+    );
+    runFerret(tmpDir, ['scan']);
+    fs.writeFileSync(
+      contractPath,
+      '---\nferret:\n  id: api.breaking\n  type: api\n  shape:\n    type: object\n    properties:\n      id:\n        type: string\n---\n',
+      'utf-8',
+    );
+    runFerret(tmpDir, ['scan', '--force']);
+    const result = runFerret(tmpDir, ['status', '--json']);
+    assert.equal(result.status, 0);
+    const json = JSON.parse(result.stdout) as { needsReview: number; contracts: Array<{ status: string }> };
+    assert.equal(json.needsReview, 1);
+    assert.ok(
+      json.contracts.every((c) => c.status === 'needs-review'),
+      'contracts array should only include needs-review entries',
+    );
+  });
+
+  stableIt('--export writes STATUS.md to project root', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'contracts', 'api.contract.md'),
+      '---\nferret:\n  id: api.endpoint\n  type: api\n  shape:\n    type: object\n---\n',
+      'utf-8',
+    );
+    runFerret(tmpDir, ['scan']);
+    const result = runFerret(tmpDir, ['status', '--export']);
+    assert.equal(result.status, 0);
+    const statusMdPath = path.join(tmpDir, 'STATUS.md');
+    assert.ok(fs.existsSync(statusMdPath), 'STATUS.md should be created');
+    const content = fs.readFileSync(statusMdPath, 'utf-8');
+    assert.match(content, /# Contract Status/);
+    assert.match(content, /api\.endpoint/);
+  });
+
+  stableIt('exits 0 even when contracts need review', () => {
+    const contractPath = path.join(tmpDir, 'contracts', 'api.contract.md');
+    fs.writeFileSync(
+      contractPath,
+      '---\nferret:\n  id: api.breaking\n  type: api\n  shape:\n    type: object\n    properties:\n      id:\n        type: string\n    required:\n      - id\n---\n',
+      'utf-8',
+    );
+    runFerret(tmpDir, ['scan']);
+    fs.writeFileSync(
+      contractPath,
+      '---\nferret:\n  id: api.breaking\n  type: api\n  shape:\n    type: object\n    properties:\n      id:\n        type: string\n---\n',
+      'utf-8',
+    );
+    runFerret(tmpDir, ['scan', '--force']);
+    const result = runFerret(tmpDir, ['status']);
+    assert.equal(result.status, 0, 'status must always exit 0');
+  });
+});

--- a/packages/cli/bin/commands/status.ts
+++ b/packages/cli/bin/commands/status.ts
@@ -20,18 +20,17 @@ export const statusCommand = new Command('status')
         fs.writeFileSync(path.join(root, 'STATUS.md'), markdown, 'utf-8');
         process.stdout.write('ferret status  STATUS.md written\n');
         process.exit(0);
-        return;
       }
 
       if (options.json) {
         const output = { ...report, contracts: report.contracts.filter((c) => c.status === 'needs-review') };
         process.stdout.write(JSON.stringify(output, null, 2) + '\n');
         process.exit(0);
-        return;
       }
 
       process.stdout.write(`ferret status  ${report.total} contract${report.total !== 1 ? 's' : ''}\n`);
       process.stdout.write(`\n  stable        ${report.stable}\n`);
+      if (report.roadmap > 0) process.stdout.write(`  roadmap       ${report.roadmap}\n`);
       process.stdout.write(`  needs-review  ${report.needsReview}\n`);
       const needsReview = report.contracts.filter((c) => c.status === 'needs-review');
       if (needsReview.length > 0) {

--- a/packages/cli/bin/commands/status.ts
+++ b/packages/cli/bin/commands/status.ts
@@ -1,0 +1,48 @@
+import { Command } from 'commander';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import pc from 'picocolors';
+import { findProjectRoot, getStore, buildStatusReport, buildStatusMarkdown } from '@specferret/core';
+
+export const statusCommand = new Command('status')
+  .description('Report current contract drift state (read-only, always exits 0).')
+  .option('--json', 'Machine-readable JSON output, no ANSI codes')
+  .option('--export', 'Write STATUS.md to the project root')
+  .action(async (options) => {
+    const root = findProjectRoot();
+    const store = await getStore();
+    try {
+      await store.init();
+      const report = await buildStatusReport(store);
+
+      if (options.export) {
+        const markdown = buildStatusMarkdown(report);
+        fs.writeFileSync(path.join(root, 'STATUS.md'), markdown, 'utf-8');
+        process.stdout.write('ferret status  STATUS.md written\n');
+        process.exit(0);
+        return;
+      }
+
+      if (options.json) {
+        const output = { ...report, contracts: report.contracts.filter((c) => c.status === 'needs-review') };
+        process.stdout.write(JSON.stringify(output, null, 2) + '\n');
+        process.exit(0);
+        return;
+      }
+
+      process.stdout.write(`ferret status  ${report.total} contract${report.total !== 1 ? 's' : ''}\n`);
+      process.stdout.write(`\n  stable        ${report.stable}\n`);
+      process.stdout.write(`  needs-review  ${report.needsReview}\n`);
+      const needsReview = report.contracts.filter((c) => c.status === 'needs-review');
+      if (needsReview.length > 0) {
+        process.stdout.write('\n  NEEDS REVIEW\n');
+        for (const c of needsReview) {
+          process.stdout.write(`  ${pc.red(c.id)}  ${c.driftClass} — ${c.dependentCount} dependent${c.dependentCount !== 1 ? 's' : ''}\n`);
+        }
+      }
+      process.stdout.write('\n');
+      process.exit(0);
+    } finally {
+      await store.close();
+    }
+  });

--- a/packages/cli/bin/ferret.ts
+++ b/packages/cli/bin/ferret.ts
@@ -13,12 +13,13 @@ async function main(): Promise<void> {
 
   program.name('ferret').description('SpecFerret keeps your specs honest.').version(VERSION);
 
-  const [{ initCommand }, { scanCommand }, { lintCommand }, { extractCommand }, { reviewCommand }] = await Promise.all([
+  const [{ initCommand }, { scanCommand }, { lintCommand }, { extractCommand }, { reviewCommand }, { statusCommand }] = await Promise.all([
     import('./commands/init.js'),
     import('./commands/scan.js'),
     import('./commands/lint.js'),
     import('./commands/extract.js'),
     import('./commands/review.js'),
+    import('./commands/status.js'),
   ]);
 
   program.addCommand(initCommand);
@@ -26,6 +27,7 @@ async function main(): Promise<void> {
   program.addCommand(lintCommand);
   program.addCommand(extractCommand);
   program.addCommand(reviewCommand);
+  program.addCommand(statusCommand);
 
   await program.parseAsync(process.argv);
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,3 +17,4 @@ export * from './reconciler/import-suggestions.js';
 export * from './config.js';
 export * from './utils/paths.js';
 export * from './contract.js';
+export * from './status/index.js';

--- a/packages/core/src/status/index.ts
+++ b/packages/core/src/status/index.ts
@@ -1,0 +1,66 @@
+import type { DBStore, ContractStatus } from '../store/types.js';
+
+export type StatusContractEntry = {
+  id: string;
+  status: ContractStatus;
+  driftClass: 'breaking' | 'stable' | 'roadmap';
+  dependentCount: number;
+  dependents: string[];
+};
+
+export type StatusReport = {
+  version: '2.0';
+  timestamp: string;
+  total: number;
+  stable: number;
+  needsReview: number;
+  contracts: StatusContractEntry[];
+};
+
+export async function buildStatusReport(store: DBStore): Promise<StatusReport> {
+  const [contracts, nodes, deps] = await Promise.all([store.getContracts(), store.getNodes(), store.getDependencies()]);
+
+  const nodeById = new Map(nodes.map((n) => [n.id, n]));
+  const dependentsByContractId = new Map<string, string[]>();
+
+  for (const dep of deps) {
+    const node = nodeById.get(dep.source_node_id);
+    if (!node) continue;
+    const list = dependentsByContractId.get(dep.target_contract_id) ?? [];
+    list.push(node.file_path);
+    dependentsByContractId.set(dep.target_contract_id, list);
+  }
+
+  const entries: StatusContractEntry[] = contracts.map((c) => {
+    const dependents = dependentsByContractId.get(c.id) ?? [];
+    return {
+      id: c.id,
+      status: c.status,
+      driftClass: c.status === 'needs-review' ? 'breaking' : c.status === 'roadmap' ? 'roadmap' : 'stable',
+      dependentCount: dependents.length,
+      dependents,
+    };
+  });
+
+  return {
+    version: '2.0',
+    timestamp: new Date().toISOString(),
+    total: contracts.length,
+    stable: contracts.filter((c) => c.status === 'stable').length,
+    needsReview: contracts.filter((c) => c.status === 'needs-review').length,
+    contracts: entries,
+  };
+}
+
+export function buildStatusMarkdown(report: StatusReport): string {
+  const lines = [
+    '# Contract Status',
+    '',
+    `Generated: ${report.timestamp}`,
+    '',
+    '| Contract | Status | Drift Class | Dependents |',
+    '| --- | --- | --- | --- |',
+    ...report.contracts.map((c) => `| ${c.id} | ${c.status} | ${c.driftClass} | ${c.dependentCount} |`),
+  ];
+  return lines.join('\n') + '\n';
+}

--- a/packages/core/src/status/index.ts
+++ b/packages/core/src/status/index.ts
@@ -13,6 +13,7 @@ export type StatusReport = {
   timestamp: string;
   total: number;
   stable: number;
+  roadmap: number;
   needsReview: number;
   contracts: StatusContractEntry[];
 };
@@ -27,7 +28,7 @@ export async function buildStatusReport(store: DBStore): Promise<StatusReport> {
     const node = nodeById.get(dep.source_node_id);
     if (!node) continue;
     const list = dependentsByContractId.get(dep.target_contract_id) ?? [];
-    list.push(node.file_path);
+    if (!list.includes(node.file_path)) list.push(node.file_path);
     dependentsByContractId.set(dep.target_contract_id, list);
   }
 
@@ -47,6 +48,7 @@ export async function buildStatusReport(store: DBStore): Promise<StatusReport> {
     timestamp: new Date().toISOString(),
     total: contracts.length,
     stable: contracts.filter((c) => c.status === 'stable').length,
+    roadmap: contracts.filter((c) => c.status === 'roadmap').length,
     needsReview: contracts.filter((c) => c.status === 'needs-review').length,
     contracts: entries,
   };


### PR DESCRIPTION
## Summary

- Adds `ferret status` — a read-only report command that reads the current store state and prints contract drift status; **always exits 0**
- Core reporting logic in `packages/core/src/status/index.ts` (`buildStatusReport`, `buildStatusMarkdown`); CLI command ≤50 lines
- `--json` emits machine-readable JSON (needs-review contracts only, no ANSI) for CI/Warren pipeline use
- `--export` writes `STATUS.md` markdown table to project root (all contracts, id/status/drift class/dependents)

## Test plan

- [ ] `bun test` — 229 pass, 0 fail
- [ ] `ferret status` on clean project: prints `ferret status  N contracts`, exits 0
- [ ] `ferret status` on project with breaking drift: shows NEEDS REVIEW section, exits 0
- [ ] `ferret status --json`: valid JSON with `version`, `timestamp`, `total`, `stable`, `needsReview`, `contracts` fields
- [ ] `ferret status --export`: creates `STATUS.md` with markdown table
- [ ] Empty store (no scan run): prints `ferret status  0 contracts`, exits 0
- [ ] 9 dedicated tests in `status.test.ts` covering all acceptance criteria from S59